### PR TITLE
feat: add in-memory admin HTTP skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# go-rbac-microservice
+# ms-rbac-service
+
+This repository provides a lightweight prototype of an RBAC microservice implemented in Go. The current implementation focuses on administrative HTTP endpoints for managing services, roles, and permissions. Data is stored in-memory, which keeps the prototype simple while allowing the high-level API shape to be exercised.
+
+## Running locally
+
+```
+go run ./cmd/ms-rbac-service
+```
+
+The server listens on `HTTP_ADDR` (defaults to `:8080`).
+
+## Example usage
+
+Create a service:
+
+```
+curl -X SET http://localhost:8080/admin/service \
+  -H 'Content-Type: application/json' \
+  -d '{"key":"example","title":"Example Service"}'
+```
+
+List services:
+
+```
+curl http://localhost:8080/admin/service-list
+```

--- a/cmd/ms-rbac-service/main.go
+++ b/cmd/ms-rbac-service/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/example/ms-rbac-service/internal/app"
+)
+
+func main() {
+	srv, err := app.Bootstrap()
+	if err != nil {
+		log.Fatalf("bootstrap failed: %v", err)
+	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("server error: %v", err)
+		}
+	}()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
+
+	if err := app.Shutdown(context.Background(), srv); err != nil {
+		log.Printf("shutdown error: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/ms-rbac-service
+
+go 1.25.1

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -1,0 +1,39 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/example/ms-rbac-service/internal/config"
+	"github.com/example/ms-rbac-service/internal/repo"
+	"github.com/example/ms-rbac-service/internal/server"
+	"github.com/example/ms-rbac-service/internal/usecase"
+)
+
+// Bootstrap wires dependencies and returns an HTTP server instance.
+func Bootstrap() (*http.Server, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	repository := repo.New()
+	serviceUC := usecase.NewServiceUsecase(repository)
+	roleUC := usecase.NewRoleUsecase(repository)
+	permissionUC := usecase.NewPermissionUsecase(repository)
+
+	srv := server.New(serviceUC, roleUC, permissionUC)
+	httpServer := &http.Server{
+		Addr:    cfg.HTTPAddr,
+		Handler: srv,
+	}
+	return httpServer, nil
+}
+
+// Shutdown gracefully terminates the HTTP server.
+func Shutdown(ctx context.Context, srv *http.Server) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	return srv.Shutdown(ctx)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+    "fmt"
+    "os"
+    "strconv"
+    "time"
+)
+
+// Config holds environment driven settings for the service.
+type Config struct {
+    AppEnv              string
+    HTTPAddr            string
+    DBDSN               string
+    NATSURL             string
+    AuthModeratorIss    string
+    AuthModeratorAud    string
+    CacheTTL            time.Duration
+}
+
+// Load reads configuration from environment variables applying defaults where necessary.
+func Load() (Config, error) {
+    cfg := Config{
+        AppEnv:           getEnv("APP_ENV", "dev"),
+        HTTPAddr:         getEnv("HTTP_ADDR", ":8080"),
+        DBDSN:            os.Getenv("DB_DSN"),
+        NATSURL:          getEnv("NATS_URL", "nats://nats:4222"),
+        AuthModeratorIss: os.Getenv("AUTH_MODERATOR_JWT_ISS"),
+        AuthModeratorAud: os.Getenv("AUTH_MODERATOR_JWT_AUD"),
+    }
+    ttl, err := parseDurationSeconds(getEnv("CACHE_TTL_SECONDS", "60"))
+    if err != nil {
+        return Config{}, fmt.Errorf("invalid CACHE_TTL_SECONDS: %w", err)
+    }
+    cfg.CacheTTL = ttl
+    return cfg, nil
+}
+
+func getEnv(key, fallback string) string {
+    if v := os.Getenv(key); v != "" {
+        return v
+    }
+    return fallback
+}
+
+func parseDurationSeconds(v string) (time.Duration, error) {
+    sec, err := strconv.Atoi(v)
+    if err != nil {
+        return 0, err
+    }
+    return time.Duration(sec) * time.Second, nil
+}

--- a/internal/domain/model/models.go
+++ b/internal/domain/model/models.go
@@ -1,0 +1,84 @@
+package model
+
+// Service represents an external system registered within RBAC.
+type Service struct {
+	ID    string
+	Key   string
+	Title string
+}
+
+// Role represents a named role with a key.
+type Role struct {
+	ID    string
+	Key   string
+	Title string
+}
+
+// Permission represents an action that can be applied to a resource kind.
+type Permission struct {
+	ID           string
+	Action       string
+	ResourceKind string
+}
+
+type RoleHierarchy struct {
+	RoleID       string
+	ParentRoleID string
+}
+
+type RolePermission struct {
+	RoleID       string
+	PermissionID string
+	ResourceID   *string
+}
+
+type ServiceRole struct {
+	RoleID    string
+	ServiceID string
+}
+
+type ServicePermission struct {
+	PermissionID string
+	ServiceID    string
+}
+
+type PrincipalKind string
+
+const (
+	PrincipalKindUser           PrincipalKind = "user"
+	PrincipalKindServiceAccount PrincipalKind = "service_account"
+	PrincipalKindGroup          PrincipalKind = "group"
+)
+
+type PrincipalRole struct {
+	PrincipalID   string
+	PrincipalKind PrincipalKind
+	RoleID        string
+	TenantID      *string
+	ServiceID     *string
+	ResourceKind  *string
+	ResourceID    *string
+}
+
+type OverrideEffect string
+
+const (
+	OverrideEffectAllow OverrideEffect = "allow"
+	OverrideEffectDeny  OverrideEffect = "deny"
+)
+
+type PrincipalOverride struct {
+	PrincipalID   string
+	PrincipalKind PrincipalKind
+	PermissionID  string
+	Effect        OverrideEffect
+	TenantID      *string
+	ServiceID     *string
+	ResourceKind  *string
+	ResourceID    *string
+}
+
+type SuperadminPrincipal struct {
+	PrincipalID   string
+	PrincipalKind PrincipalKind
+}

--- a/internal/domain/pdp/decision.go
+++ b/internal/domain/pdp/decision.go
@@ -1,0 +1,67 @@
+package pdp
+
+import "github.com/example/ms-rbac-service/internal/domain/model"
+
+// CheckRequest represents a PDP input payload.
+type CheckRequest struct {
+	PrincipalID   string
+	PrincipalKind model.PrincipalKind
+	TenantID      *string
+	ServiceID     *string
+	Action        string
+	ResourceKind  string
+	ResourceID    *string
+	CorrelationID string
+}
+
+// CheckResult represents the decision returned by the PDP engine.
+type CheckResult struct {
+	Allow         bool     `json:"allow"`
+	Decision      string   `json:"decision"`
+	RoleKeys      []string `json:"role_keys,omitempty"`
+	CorrelationID string   `json:"correlation_id,omitempty"`
+}
+
+// ExplainResult enriches the response with the matched artefacts.
+type ExplainResult struct {
+	Allow    bool        `json:"allow"`
+	Decision string      `json:"decision"`
+	Matched  interface{} `json:"matched,omitempty"`
+}
+
+// Repository is the contract required by the PDP engine for loading state.
+type Repository interface {
+	IsSuperAdmin(principalID string, kind model.PrincipalKind) (bool, error)
+	FindMostSpecificOverride(req CheckRequest) (*OverrideMatch, error)
+	ResolveRoles(req CheckRequest) ([]RoleWithScope, error)
+	ListPermissionsForRoles(roleIDs []string) ([]RolePermissionItem, error)
+}
+
+type OverrideMatch struct {
+	Effect       model.OverrideEffect
+	PermissionID string
+	Scope        OverrideScope
+}
+
+type OverrideScope struct {
+	TenantID     *string
+	ServiceID    *string
+	ResourceKind *string
+	ResourceID   *string
+}
+
+type RoleWithScope struct {
+	RoleID     string
+	RoleKey    string
+	Scope      OverrideScope
+	ServiceIDs []string
+}
+
+type RolePermissionItem struct {
+	RoleID       string
+	RoleKey      string
+	PermissionID string
+	Action       string
+	ResourceKind string
+	ResourceID   *string
+}

--- a/internal/pdp/cache.go
+++ b/internal/pdp/cache.go
@@ -1,0 +1,49 @@
+package pdp
+
+import (
+	"sync"
+	"time"
+
+	"github.com/example/ms-rbac-service/internal/domain/pdp"
+)
+
+type cacheEntry struct {
+	result    pdp.CheckResult
+	expiresAt time.Time
+}
+
+// Cache provides a simple TTL bound cache for PDP decisions.
+type Cache struct {
+	ttl    time.Duration
+	mu     sync.RWMutex
+	values map[string]cacheEntry
+}
+
+// NewCache creates a cache with the provided TTL.
+func NewCache(ttl time.Duration) *Cache {
+	return &Cache{
+		ttl:    ttl,
+		values: make(map[string]cacheEntry),
+	}
+}
+
+// Get fetches a decision by key.
+func (c *Cache) Get(key string) (pdp.CheckResult, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.values[key]
+	if !ok {
+		return pdp.CheckResult{}, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		return pdp.CheckResult{}, false
+	}
+	return entry.result, true
+}
+
+// Set stores a decision result.
+func (c *Cache) Set(key string, result pdp.CheckResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.values[key] = cacheEntry{result: result, expiresAt: time.Now().Add(c.ttl)}
+}

--- a/internal/pdp/engine.go
+++ b/internal/pdp/engine.go
@@ -1,0 +1,141 @@
+package pdp
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/example/ms-rbac-service/internal/domain/model"
+	domainpdp "github.com/example/ms-rbac-service/internal/domain/pdp"
+)
+
+// Engine evaluates authorisation requests using repository backed data.
+type Engine struct {
+	repo domainpdp.Repository
+}
+
+// NewEngine constructs a new Engine instance.
+func NewEngine(repo domainpdp.Repository) *Engine {
+	return &Engine{repo: repo}
+}
+
+// Check executes a single PDP decision.
+func (e *Engine) Check(ctx context.Context, req domainpdp.CheckRequest) (domainpdp.CheckResult, error) {
+	// Rule 1: superadmin
+	isSuper, err := e.repo.IsSuperAdmin(req.PrincipalID, req.PrincipalKind)
+	if err != nil {
+		return domainpdp.CheckResult{}, err
+	}
+	if isSuper {
+		return domainpdp.CheckResult{Allow: true, Decision: "superadmin", RoleKeys: nil, CorrelationID: req.CorrelationID}, nil
+	}
+
+	// Rule 2: overrides with specificity ordering
+	override, err := e.repo.FindMostSpecificOverride(req)
+	if err != nil {
+		return domainpdp.CheckResult{}, err
+	}
+	if override != nil {
+		allow := override.Effect == model.OverrideEffectAllow
+		decision := "override"
+		if !allow {
+			decision = "deny"
+		}
+		return domainpdp.CheckResult{Allow: allow, Decision: decision, CorrelationID: req.CorrelationID}, nil
+	}
+
+	roles, err := e.repo.ResolveRoles(req)
+	if err != nil {
+		return domainpdp.CheckResult{}, err
+	}
+	if len(roles) == 0 {
+		return domainpdp.CheckResult{Allow: false, Decision: "deny", CorrelationID: req.CorrelationID}, nil
+	}
+
+	roleIDs := make([]string, 0, len(roles))
+	roleKeys := make([]string, 0, len(roles))
+	for _, r := range roles {
+		roleIDs = append(roleIDs, r.RoleID)
+		roleKeys = append(roleKeys, r.RoleKey)
+	}
+
+	perms, err := e.repo.ListPermissionsForRoles(roleIDs)
+	if err != nil {
+		return domainpdp.CheckResult{}, err
+	}
+
+	if matchPermission(perms, req.Action, req.ResourceKind, req.ResourceID, req.ServiceID, roles) {
+		return domainpdp.CheckResult{Allow: true, Decision: "role", RoleKeys: roleKeys, CorrelationID: req.CorrelationID}, nil
+	}
+	return domainpdp.CheckResult{Allow: false, Decision: "deny", RoleKeys: roleKeys, CorrelationID: req.CorrelationID}, nil
+}
+
+func matchPermission(perms []domainpdp.RolePermissionItem, action, resourceKind string, resourceID *string, serviceID *string, roles []domainpdp.RoleWithScope) bool {
+	if len(perms) == 0 {
+		return false
+	}
+
+	roleScopes := map[string]domainpdp.OverrideScope{}
+	roleServiceLimit := map[string][]string{}
+	for _, r := range roles {
+		roleScopes[r.RoleID] = r.Scope
+		if len(r.ServiceIDs) > 0 {
+			roleServiceLimit[r.RoleID] = r.ServiceIDs
+		}
+	}
+
+	// pre-sort service limits for binary search
+	for _, ids := range roleServiceLimit {
+		sort.Strings(ids)
+	}
+
+	for _, p := range perms {
+		scope := roleScopes[p.RoleID]
+		if !scopeMatches(scope, serviceID, resourceKind, resourceID) {
+			continue
+		}
+		if ids, ok := roleServiceLimit[p.RoleID]; ok {
+			if serviceID == nil {
+				continue
+			}
+			idx := sort.SearchStrings(ids, *serviceID)
+			if idx >= len(ids) || ids[idx] != *serviceID {
+				continue
+			}
+		}
+		if p.Action != action {
+			continue
+		}
+		if p.ResourceKind != resourceKind && p.ResourceKind != "*" {
+			continue
+		}
+		if p.ResourceID != nil {
+			if resourceID == nil || *p.ResourceID != *resourceID {
+				continue
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func scopeMatches(scope domainpdp.OverrideScope, serviceID *string, resourceKind string, resourceID *string) bool {
+	if scope.ServiceID != nil {
+		if serviceID == nil || *scope.ServiceID != *serviceID {
+			return false
+		}
+	}
+	if scope.ResourceKind != nil {
+		if *scope.ResourceKind != resourceKind {
+			return false
+		}
+	}
+	if scope.ResourceID != nil {
+		if resourceID == nil || *scope.ResourceID != *resourceID {
+			return false
+		}
+	}
+	return true
+}
+
+var ErrRepositoryNotImplemented = errors.New("repository method not implemented")

--- a/internal/repo/models.go
+++ b/internal/repo/models.go
@@ -1,0 +1,87 @@
+package repo
+
+import "time"
+
+type BaseModel struct {
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type Service struct {
+	ID    string
+	Key   string
+	Title string
+	BaseModel
+}
+
+type Role struct {
+	ID    string
+	Key   string
+	Title string
+	BaseModel
+}
+
+type RoleHierarchy struct {
+	RoleID       string
+	ParentRoleID string
+	BaseModel
+}
+
+type Permission struct {
+	ID           string
+	Action       string
+	ResourceKind string
+	BaseModel
+}
+
+type RolePermission struct {
+	RoleID       string
+	PermissionID string
+	ResourceID   *string
+	BaseModel
+}
+
+type ServiceRole struct {
+	RoleID    string
+	ServiceID string
+	BaseModel
+}
+
+type ServicePermission struct {
+	PermissionID string
+	ServiceID    string
+	BaseModel
+}
+
+type PrincipalKind string
+
+type PrincipalRole struct {
+	PrincipalID   string
+	PrincipalKind PrincipalKind
+	RoleID        string
+	TenantID      *string
+	ServiceID     *string
+	ResourceKind  *string
+	ResourceID    *string
+	BaseModel
+}
+
+type OverrideEffect string
+
+type PrincipalOverride struct {
+	PrincipalID   string
+	PrincipalKind PrincipalKind
+	PermissionID  string
+	Effect        OverrideEffect
+	TenantID      *string
+	ServiceID     *string
+	ResourceKind  *string
+	ResourceID    *string
+	BaseModel
+}
+
+type SuperadminPrincipal struct {
+	PrincipalID   string
+	PrincipalKind PrincipalKind
+	BaseModel
+}

--- a/internal/repo/repository.go
+++ b/internal/repo/repository.go
@@ -1,0 +1,215 @@
+package repo
+
+import (
+    "context"
+    "errors"
+    "sync"
+    "time"
+
+    domainpdp "github.com/example/ms-rbac-service/internal/domain/pdp"
+    "github.com/example/ms-rbac-service/internal/domain/model"
+)
+
+// Repository provides in-memory storage for RBAC entities.
+type Repository struct {
+    mu sync.RWMutex
+
+    services    map[string]Service
+    roles       map[string]Role
+    permissions map[string]Permission
+}
+
+// New initialises an empty repository.
+func New() *Repository {
+    return &Repository{
+        services:    make(map[string]Service),
+        roles:       make(map[string]Role),
+        permissions: make(map[string]Permission),
+    }
+}
+
+func (r *Repository) now() time.Time {
+    return time.Now().UTC()
+}
+
+func (r *Repository) CreateService(ctx context.Context, service *Service) error {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    service.ID = generateID()
+    service.CreatedAt = r.now()
+    service.UpdatedAt = service.CreatedAt
+    r.services[service.ID] = *service
+    return nil
+}
+
+func (r *Repository) UpdateService(ctx context.Context, id string, title string) error {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    svc, ok := r.services[id]
+    if !ok {
+        return ErrNotFound
+    }
+    svc.Title = title
+    svc.UpdatedAt = r.now()
+    r.services[id] = svc
+    return nil
+}
+
+func (r *Repository) GetService(ctx context.Context, id string) (*Service, error) {
+    r.mu.RLock()
+    defer r.mu.RUnlock()
+    svc, ok := r.services[id]
+    if !ok {
+        return nil, ErrNotFound
+    }
+    cp := svc
+    return &cp, nil
+}
+
+func (r *Repository) ListServices(ctx context.Context, offset, limit int) ([]Service, int64, error) {
+    r.mu.RLock()
+    defer r.mu.RUnlock()
+    items := make([]Service, 0, len(r.services))
+    for _, svc := range r.services {
+        items = append(items, svc)
+    }
+    total := int64(len(items))
+    start := clamp(offset, 0, len(items))
+    end := clamp(offset+limit, start, len(items))
+    return items[start:end], total, nil
+}
+
+func (r *Repository) CreateRole(ctx context.Context, role *Role) error {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    role.ID = generateID()
+    role.CreatedAt = r.now()
+    role.UpdatedAt = role.CreatedAt
+    r.roles[role.ID] = *role
+    return nil
+}
+
+func (r *Repository) UpdateRole(ctx context.Context, id string, title string) error {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    rl, ok := r.roles[id]
+    if !ok {
+        return ErrNotFound
+    }
+    rl.Title = title
+    rl.UpdatedAt = r.now()
+    r.roles[id] = rl
+    return nil
+}
+
+func (r *Repository) GetRole(ctx context.Context, id string) (*Role, error) {
+    r.mu.RLock()
+    defer r.mu.RUnlock()
+    rl, ok := r.roles[id]
+    if !ok {
+        return nil, ErrNotFound
+    }
+    cp := rl
+    return &cp, nil
+}
+
+func (r *Repository) ListRoles(ctx context.Context, offset, limit int) ([]Role, int64, error) {
+    r.mu.RLock()
+    defer r.mu.RUnlock()
+    items := make([]Role, 0, len(r.roles))
+    for _, rl := range r.roles {
+        items = append(items, rl)
+    }
+    total := int64(len(items))
+    start := clamp(offset, 0, len(items))
+    end := clamp(offset+limit, start, len(items))
+    return items[start:end], total, nil
+}
+
+func (r *Repository) CreatePermission(ctx context.Context, p *Permission) error {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    p.ID = generateID()
+    p.CreatedAt = r.now()
+    p.UpdatedAt = p.CreatedAt
+    r.permissions[p.ID] = *p
+    return nil
+}
+
+func (r *Repository) UpdatePermission(ctx context.Context, id string, attrs map[string]interface{}) error {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    item, ok := r.permissions[id]
+    if !ok {
+        return ErrNotFound
+    }
+    if v, ok := attrs["action"].(string); ok {
+        item.Action = v
+    }
+    if v, ok := attrs["resource_kind"].(string); ok {
+        item.ResourceKind = v
+    }
+    item.UpdatedAt = r.now()
+    r.permissions[id] = item
+    return nil
+}
+
+func (r *Repository) GetPermission(ctx context.Context, id string) (*Permission, error) {
+    r.mu.RLock()
+    defer r.mu.RUnlock()
+    item, ok := r.permissions[id]
+    if !ok {
+        return nil, ErrNotFound
+    }
+    cp := item
+    return &cp, nil
+}
+
+func (r *Repository) ListPermissions(ctx context.Context, offset, limit int) ([]Permission, int64, error) {
+    r.mu.RLock()
+    defer r.mu.RUnlock()
+    items := make([]Permission, 0, len(r.permissions))
+    for _, p := range r.permissions {
+        items = append(items, p)
+    }
+    total := int64(len(items))
+    start := clamp(offset, 0, len(items))
+    end := clamp(offset+limit, start, len(items))
+    return items[start:end], total, nil
+}
+
+// PDP contracts - not yet implemented for in-memory stub.
+func (r *Repository) IsSuperAdmin(principalID string, kind model.PrincipalKind) (bool, error) {
+    return false, ErrNotImplemented
+}
+
+func (r *Repository) FindMostSpecificOverride(req domainpdp.CheckRequest) (*domainpdp.OverrideMatch, error) {
+    return nil, ErrNotImplemented
+}
+
+func (r *Repository) ResolveRoles(req domainpdp.CheckRequest) ([]domainpdp.RoleWithScope, error) {
+    return nil, ErrNotImplemented
+}
+
+func (r *Repository) ListPermissionsForRoles(roleIDs []string) ([]domainpdp.RolePermissionItem, error) {
+    return nil, ErrNotImplemented
+}
+
+var (
+    ErrNotFound       = errors.New("record not found")
+    ErrNotImplemented = errors.New("not implemented")
+)
+
+func clamp(v, min, max int) int {
+    if v < min {
+        return min
+    }
+    if v > max {
+        return max
+    }
+    return v
+}
+
+func generateID() string {
+    return time.Now().UTC().Format("20060102150405.000000000")
+}

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -1,0 +1,267 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/example/ms-rbac-service/internal/usecase"
+	"github.com/example/ms-rbac-service/pkg/pagination"
+)
+
+type Server struct {
+	mux          *http.ServeMux
+	serviceUC    *usecase.ServiceUsecase
+	roleUC       *usecase.RoleUsecase
+	permissionUC *usecase.PermissionUsecase
+}
+
+func New(serviceUC *usecase.ServiceUsecase, roleUC *usecase.RoleUsecase, permissionUC *usecase.PermissionUsecase) *Server {
+	s := &Server{
+		mux:          http.NewServeMux(),
+		serviceUC:    serviceUC,
+		roleUC:       roleUC,
+		permissionUC: permissionUC,
+	}
+	s.routes()
+	return s
+}
+
+func (s *Server) routes() {
+	s.mux.HandleFunc("/admin/service", s.handleService)
+	s.mux.HandleFunc("/admin/service/", s.handleService)
+	s.mux.HandleFunc("/admin/service-list", s.handleServiceList)
+	s.mux.HandleFunc("/admin/role", s.handleRole)
+	s.mux.HandleFunc("/admin/role/", s.handleRole)
+	s.mux.HandleFunc("/admin/role-list", s.handleRoleList)
+	s.mux.HandleFunc("/admin/permission", s.handlePermission)
+	s.mux.HandleFunc("/admin/permission/", s.handlePermission)
+	s.mux.HandleFunc("/admin/permission-list", s.handlePermissionList)
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+type createServiceRequest struct {
+	Key   string `json:"key"`
+	Title string `json:"title"`
+}
+
+type updateServiceRequest struct {
+	Title string `json:"title"`
+}
+
+func (s *Server) handleService(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/admin/service")
+	switch {
+	case r.Method == "SET" && (path == "" || path == "/"):
+		var payload createServiceRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid payload")
+			return
+		}
+		item, err := s.serviceUC.Create(r.Context(), payload.Key, payload.Title)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusCreated, item)
+	case r.Method == "PUT" && strings.HasPrefix(path, "/"):
+		id := strings.TrimPrefix(path, "/")
+		var payload updateServiceRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid payload")
+			return
+		}
+		if err := s.serviceUC.Update(r.Context(), id, payload.Title); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	case r.Method == "GET" && strings.HasPrefix(path, "/"):
+		id := strings.TrimPrefix(path, "/")
+		item, err := s.serviceUC.Get(r.Context(), id)
+		if err != nil {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, item)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *Server) handleServiceList(w http.ResponseWriter, r *http.Request) {
+	params := parsePagination(r)
+	items, total, err := s.serviceUC.List(r.Context(), params)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, pagination.Result{Items: items, Page: params.Page, PageSize: params.PageSize, Total: total})
+}
+
+type createRoleRequest struct {
+	Key   string `json:"key"`
+	Title string `json:"title"`
+}
+
+type updateRoleRequest struct {
+	Title string `json:"title"`
+}
+
+func (s *Server) handleRole(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/admin/role")
+	switch {
+	case r.Method == "SET" && (path == "" || path == "/"):
+		var payload createRoleRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid payload")
+			return
+		}
+		item, err := s.roleUC.Create(r.Context(), payload.Key, payload.Title)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusCreated, item)
+	case r.Method == "PUT" && strings.HasPrefix(path, "/"):
+		id := strings.TrimPrefix(path, "/")
+		var payload updateRoleRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid payload")
+			return
+		}
+		if err := s.roleUC.Update(r.Context(), id, payload.Title); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	case r.Method == "GET" && strings.HasPrefix(path, "/"):
+		id := strings.TrimPrefix(path, "/")
+		item, err := s.roleUC.Get(r.Context(), id)
+		if err != nil {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, item)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *Server) handleRoleList(w http.ResponseWriter, r *http.Request) {
+	params := parsePagination(r)
+	items, total, err := s.roleUC.List(r.Context(), params)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, pagination.Result{Items: items, Page: params.Page, PageSize: params.PageSize, Total: total})
+}
+
+type createPermissionRequest struct {
+	Action       string `json:"action"`
+	ResourceKind string `json:"resource_kind"`
+}
+
+type updatePermissionRequest struct {
+	Action       *string `json:"action"`
+	ResourceKind *string `json:"resource_kind"`
+}
+
+func (s *Server) handlePermission(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/admin/permission")
+	switch {
+	case r.Method == "SET" && (path == "" || path == "/"):
+		var payload createPermissionRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid payload")
+			return
+		}
+		item, err := s.permissionUC.Create(r.Context(), payload.Action, payload.ResourceKind)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusCreated, item)
+	case r.Method == "PUT" && strings.HasPrefix(path, "/"):
+		id := strings.TrimPrefix(path, "/")
+		var payload updatePermissionRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid payload")
+			return
+		}
+		attrs := map[string]interface{}{}
+		if payload.Action != nil {
+			attrs["action"] = *payload.Action
+		}
+		if payload.ResourceKind != nil {
+			attrs["resource_kind"] = *payload.ResourceKind
+		}
+		if len(attrs) == 0 {
+			writeError(w, http.StatusBadRequest, "no updates supplied")
+			return
+		}
+		if err := s.permissionUC.Update(r.Context(), id, attrs); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	case r.Method == "GET" && strings.HasPrefix(path, "/"):
+		id := strings.TrimPrefix(path, "/")
+		item, err := s.permissionUC.Get(r.Context(), id)
+		if err != nil {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, item)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *Server) handlePermissionList(w http.ResponseWriter, r *http.Request) {
+	params := parsePagination(r)
+	items, total, err := s.permissionUC.List(r.Context(), params)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, pagination.Result{Items: items, Page: params.Page, PageSize: params.PageSize, Total: total})
+}
+
+func parsePagination(r *http.Request) pagination.Params {
+	q := r.URL.Query()
+	page := parseInt(q.Get("page"))
+	pageSize := parseInt(q.Get("pageSize"))
+	return pagination.NewParams(page, pageSize)
+}
+
+func parseInt(v string) int {
+	if v == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    "RBAC_ERROR",
+			"message": message,
+		},
+	})
+}

--- a/internal/usecase/errors.go
+++ b/internal/usecase/errors.go
@@ -1,0 +1,7 @@
+package usecase
+
+import "errors"
+
+var (
+    ErrValidation = errors.New("validation error")
+)

--- a/internal/usecase/permission.go
+++ b/internal/usecase/permission.go
@@ -1,0 +1,36 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/example/ms-rbac-service/internal/repo"
+	"github.com/example/ms-rbac-service/pkg/pagination"
+)
+
+type PermissionUsecase struct {
+	repo *repo.Repository
+}
+
+func NewPermissionUsecase(r *repo.Repository) *PermissionUsecase {
+	return &PermissionUsecase{repo: r}
+}
+
+func (uc *PermissionUsecase) Create(ctx context.Context, action, resourceKind string) (*repo.Permission, error) {
+	item := &repo.Permission{Action: action, ResourceKind: resourceKind}
+	if err := uc.repo.CreatePermission(ctx, item); err != nil {
+		return nil, err
+	}
+	return item, nil
+}
+
+func (uc *PermissionUsecase) Update(ctx context.Context, id string, attrs map[string]interface{}) error {
+	return uc.repo.UpdatePermission(ctx, id, attrs)
+}
+
+func (uc *PermissionUsecase) Get(ctx context.Context, id string) (*repo.Permission, error) {
+	return uc.repo.GetPermission(ctx, id)
+}
+
+func (uc *PermissionUsecase) List(ctx context.Context, params pagination.Params) ([]repo.Permission, int64, error) {
+	return uc.repo.ListPermissions(ctx, params.Offset(), params.PageSize)
+}

--- a/internal/usecase/role.go
+++ b/internal/usecase/role.go
@@ -1,0 +1,36 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/example/ms-rbac-service/internal/repo"
+	"github.com/example/ms-rbac-service/pkg/pagination"
+)
+
+type RoleUsecase struct {
+	repo *repo.Repository
+}
+
+func NewRoleUsecase(r *repo.Repository) *RoleUsecase {
+	return &RoleUsecase{repo: r}
+}
+
+func (uc *RoleUsecase) Create(ctx context.Context, key, title string) (*repo.Role, error) {
+	role := &repo.Role{Key: key, Title: title}
+	if err := uc.repo.CreateRole(ctx, role); err != nil {
+		return nil, err
+	}
+	return role, nil
+}
+
+func (uc *RoleUsecase) Update(ctx context.Context, id, title string) error {
+	return uc.repo.UpdateRole(ctx, id, title)
+}
+
+func (uc *RoleUsecase) Get(ctx context.Context, id string) (*repo.Role, error) {
+	return uc.repo.GetRole(ctx, id)
+}
+
+func (uc *RoleUsecase) List(ctx context.Context, params pagination.Params) ([]repo.Role, int64, error) {
+	return uc.repo.ListRoles(ctx, params.Offset(), params.PageSize)
+}

--- a/internal/usecase/service.go
+++ b/internal/usecase/service.go
@@ -1,0 +1,36 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/example/ms-rbac-service/internal/repo"
+	"github.com/example/ms-rbac-service/pkg/pagination"
+)
+
+type ServiceUsecase struct {
+	repo *repo.Repository
+}
+
+func NewServiceUsecase(r *repo.Repository) *ServiceUsecase {
+	return &ServiceUsecase{repo: r}
+}
+
+func (uc *ServiceUsecase) Create(ctx context.Context, key, title string) (*repo.Service, error) {
+	svc := &repo.Service{Key: key, Title: title}
+	if err := uc.repo.CreateService(ctx, svc); err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+func (uc *ServiceUsecase) Update(ctx context.Context, id, title string) error {
+	return uc.repo.UpdateService(ctx, id, title)
+}
+
+func (uc *ServiceUsecase) Get(ctx context.Context, id string) (*repo.Service, error) {
+	return uc.repo.GetService(ctx, id)
+}
+
+func (uc *ServiceUsecase) List(ctx context.Context, params pagination.Params) ([]repo.Service, int64, error) {
+	return uc.repo.ListServices(ctx, params.Offset(), params.PageSize)
+}

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,0 +1,88 @@
+create extension if not exists pgcrypto;
+
+create table service (
+  id uuid primary key default gen_random_uuid(),
+  key text unique not null,
+  title text not null
+);
+
+create table role (
+  id uuid primary key default gen_random_uuid(),
+  key text not null,
+  title text not null,
+  unique (key)
+);
+
+create table role_hierarchy (
+  role_id uuid not null references role(id) on delete cascade,
+  parent_role_id uuid not null references role(id) on delete cascade,
+  primary key (role_id, parent_role_id),
+  check (role_id <> parent_role_id)
+);
+
+create table permission (
+  id uuid primary key default gen_random_uuid(),
+  action text not null,
+  resource_kind text not null,
+  unique (action, resource_kind)
+);
+
+create table role_permission (
+  role_id uuid not null references role(id) on delete cascade,
+  permission_id uuid not null references permission(id) on delete cascade,
+  resource_id uuid,
+  primary key (role_id, permission_id, resource_id)
+);
+
+create table service_role (
+  role_id uuid not null references role(id) on delete cascade,
+  service_id uuid not null references service(id) on delete cascade,
+  primary key (role_id, service_id)
+);
+
+create table service_permission (
+  permission_id uuid not null references permission(id) on delete cascade,
+  service_id uuid not null references service(id) on delete cascade,
+  primary key (permission_id, service_id)
+);
+
+create type principal_kind as enum ('user','service_account','group');
+
+create table principal_role (
+  principal_id uuid not null,
+  principal_kind principal_kind not null,
+  role_id uuid not null references role(id) on delete cascade,
+
+  tenant_id uuid,
+  service_id uuid,
+  resource_kind text,
+  resource_id uuid,
+
+  primary key (principal_id, principal_kind, role_id, tenant_id, service_id, resource_kind, resource_id),
+  foreign key (service_id) references service(id) on delete cascade
+);
+
+create type override_effect as enum ('allow','deny');
+
+create table principal_override (
+  principal_id uuid not null,
+  principal_kind principal_kind not null,
+  permission_id uuid not null references permission(id) on delete cascade,
+  effect override_effect not null,
+
+  tenant_id uuid,
+  service_id uuid,
+  resource_kind text,
+  resource_id uuid,
+
+  primary key (principal_id, principal_kind, permission_id, tenant_id, service_id, resource_kind, resource_id),
+  foreign key (service_id) references service(id) on delete cascade
+);
+
+create table superadmin_principal (
+  principal_id uuid primary key,
+  principal_kind principal_kind not null
+);
+
+create index on principal_role (principal_id, principal_kind, tenant_id, service_id, resource_kind, resource_id);
+create index on principal_override (principal_id, principal_kind, tenant_id, service_id, resource_kind, resource_id);

--- a/pkg/pagination/pagination.go
+++ b/pkg/pagination/pagination.go
@@ -1,0 +1,50 @@
+package pagination
+
+import (
+    "math"
+)
+
+const (
+    DefaultPage     = 1
+    DefaultPageSize = 25
+    MaxPageSize     = 100
+)
+
+// Params describes pagination query parameters.
+type Params struct {
+    Page     int
+    PageSize int
+}
+
+// Result describes paginated response metadata.
+type Result struct {
+    Page     int         `json:"page"`
+    PageSize int         `json:"pageSize"`
+    Total    int64       `json:"total"`
+    Items    interface{} `json:"items"`
+}
+
+// NewParams normalises page and page size ensuring sane defaults.
+func NewParams(page, pageSize int) Params {
+    if page <= 0 {
+        page = DefaultPage
+    }
+    if pageSize <= 0 {
+        pageSize = DefaultPageSize
+    }
+    if pageSize > MaxPageSize {
+        pageSize = MaxPageSize
+    }
+    return Params{
+        Page:     page,
+        PageSize: pageSize,
+    }
+}
+
+// Offset returns the calculated offset for the provided pagination parameters.
+func (p Params) Offset() int {
+    if p.Page <= 1 {
+        return 0
+    }
+    return int(math.Max(0, float64((p.Page-1)*p.PageSize)))
+}


### PR DESCRIPTION
## Summary
- add configuration loader and bootstrap wiring for a minimal server
- implement in-memory repositories and use cases for services, roles, and permissions
- expose basic admin HTTP endpoints for managing services, roles, and permissions

## Testing
- `go test ./...`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691376e9fc388323bf0deee405d925a5)