### PR TITLE
fix: make RBAC startup wait for Postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,12 @@ services:
       POSTGRES_DB: rbacdb
     volumes:
       - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U rbac -d rbacdb"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
 
   msgo-rbac:
     container_name: ms-rbac-service
@@ -20,7 +26,9 @@ services:
       NATS_URL: "nats://nats:4222"
       DB_DSN: "postgres://rbac:rbac_password@postgres:5432/rbacdb?sslmode=disable"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
     networks:
       - default
       - ms-net

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -29,14 +29,9 @@ func Bootstrap() (*http.Server, error) {
 	if cfg.DBDSN == "" {
 		return nil, fmt.Errorf("DB_DSN is required")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	pool, err := pgxpool.New(ctx, cfg.DBDSN)
+
+	pool, err := connectPostgresWithRetry(cfg.DBDSN)
 	if err != nil {
-		return nil, err
-	}
-	if err := pool.Ping(ctx); err != nil {
-		pool.Close()
 		return nil, err
 	}
 	dbPool = pool
@@ -110,6 +105,39 @@ func Shutdown(ctx context.Context, srv *http.Server) error {
 		dbPool.Close()
 	}
 	return nil
+}
+
+func connectPostgresWithRetry(dsn string) (*pgxpool.Pool, error) {
+	const (
+		maxAttempts = 30
+		retryDelay  = 2 * time.Second
+	)
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		pool, err := pgxpool.New(ctx, dsn)
+		if err == nil {
+			err = pool.Ping(ctx)
+		}
+		cancel()
+
+		if err == nil {
+			return pool, nil
+		}
+		if pool != nil {
+			pool.Close()
+		}
+
+		lastErr = err
+		log.Printf("postgres connect attempt %d/%d failed: %v", attempt, maxAttempts, err)
+
+		if attempt < maxAttempts {
+			time.Sleep(retryDelay)
+		}
+	}
+
+	return nil, fmt.Errorf("postgres connect failed after retries: %w", lastErr)
 }
 
 func connectNATSWithRetry(url string) (*natsgo.Conn, error) {


### PR DESCRIPTION
## Что выполнено

- Добавлен retry/backoff для подключения `ms-rbac-service` к Postgres при bootstrap.
- Добавлен `healthcheck` Postgres в Docker Compose.
- `msgo-rbac` теперь ждёт `postgres: service_healthy`.
- Добавлен `restart: unless-stopped` для `msgo-rbac`.

## Проверка

- `XDG_CACHE_HOME=$PWD/.cache GOCACHE=$PWD/.cache/go-build GOMODCACHE=$PWD/.cache/gomod go test ./...`
- `docker compose config`
- `docker compose up -d --build`
- Проверено, что NATS содержит `rbac.assign-role` и `rbac.checkRole`.
- Проверено, что signin для `student1@example.com` получает `role: student` в JWT.

Closes #5