### PR TITLE
Rename ms-getway references to ms-gateway

### DIFF
--- a/test/e2e/gateway/run-tests.sh
+++ b/test/e2e/gateway/run-tests.sh
@@ -34,7 +34,7 @@ suggest_fixes() {
   local observed="$1"
   if [[ "${observed}" == *"admin gateway"* ]]; then
     cat <<'EOF'
-  - В `ms-getway/templates/admin-getway.conf.template` для RBAC переписать rewrite на `/admin/v1` (сейчас `/api/admin/v1`), либо добавить в `ms-go-rbac` алиас `/api/admin/v1`.
+  - В `ms-gateway/templates/admin-gateway.conf.template` для RBAC переписать rewrite на `/admin/v1` (сейчас `/api/admin/v1`), либо добавить в `ms-go-rbac` алиас `/api/admin/v1`.
 EOF
     return 0
   fi

--- a/test/e2e/gateway/scenarios/01_api_and_admin_gateway.sh
+++ b/test/e2e/gateway/scenarios/01_api_and_admin_gateway.sh
@@ -11,7 +11,7 @@ raw="$(http_json "${GATEWAY_URL}" "PATCH" "${RBAC_API}/principal-role/update" "$
 st="$(printf '%s\n' "${raw}" | extract_status)"
 resp="$(printf '%s\n' "${raw}" | extract_body)"
 if [[ "${st}" != "200" ]]; then
-  record_mismatch "${wiki_ref} (principal-role/update)" "HTTP 200" "HTTP ${st}" "PATCH ${RBAC_API}/principal-role/update resp=${resp}" "major" "ms-go-rbac/ms-getway"
+  record_mismatch "${wiki_ref} (principal-role/update)" "HTTP 200" "HTTP ${st}" "PATCH ${RBAC_API}/principal-role/update resp=${resp}" "major" "ms-go-rbac/ms-gateway"
   return 0
 fi
 record_ok "rbac principal-role/update returns 200"
@@ -20,7 +20,7 @@ raw="$(http_get "${GATEWAY_URL}" "${RBAC_API}/principal-role/get?user_id=${user_
 st="$(printf '%s\n' "${raw}" | extract_status)"
 resp="$(printf '%s\n' "${raw}" | extract_body)"
 if [[ "${st}" != "200" ]]; then
-  record_mismatch "${wiki_ref} (principal-role/get)" "HTTP 200" "HTTP ${st}" "GET ${RBAC_API}/principal-role/get resp=${resp}" "major" "ms-go-rbac/ms-getway"
+  record_mismatch "${wiki_ref} (principal-role/get)" "HTTP 200" "HTTP ${st}" "GET ${RBAC_API}/principal-role/get resp=${resp}" "major" "ms-go-rbac/ms-gateway"
   return 0
 fi
 record_ok "rbac principal-role/get returns 200"
@@ -30,7 +30,7 @@ admin_raw="$(http_get "${ADMIN_GATEWAY_URL}" "${RBAC_API}/service-list?page=1&pa
 admin_st="$(printf '%s\n' "${admin_raw}" | extract_status)"
 admin_resp="$(printf '%s\n' "${admin_raw}" | extract_body)"
 if [[ "${admin_st}" != "200" ]]; then
-  record_mismatch "${wiki_ref} (admin gateway)" "HTTP 200 admin service-list" "HTTP ${admin_st} (admin gateway)" "GET ${ADMIN_GATEWAY_URL}${RBAC_API}/service-list resp=${admin_resp}" "minor" "ms-getway/ms-go-rbac"
+  record_mismatch "${wiki_ref} (admin gateway)" "HTTP 200 admin service-list" "HTTP ${admin_st} (admin gateway)" "GET ${ADMIN_GATEWAY_URL}${RBAC_API}/service-list resp=${admin_resp}" "minor" "ms-gateway/ms-go-rbac"
 else
   record_ok "rbac admin service-list reachable via admin gateway"
 fi


### PR DESCRIPTION
Renames the gateway typo from ms-getway/getway to ms-gateway/gateway in docs, tests, and gateway templates. No API route behavior changes.