### PR TITLE
chore: add corrected orchestrator project context

### DIFF
--- a/.ai/agents/backend-coder.md
+++ b/.ai/agents/backend-coder.md
@@ -1,0 +1,5 @@
+<!-- agent-orchestrator:start -->
+# Backend Coder
+
+Read `.ai/service.yaml`, linked instructions, and relevant contracts before implementation. Keep domain, use-case, and adapter boundaries intact. Run only commands listed in `.ai/commands.yaml` with `requires_approval: false`. Request explicit owner approval before any command marked `requires_approval: true`.
+<!-- agent-orchestrator:end -->

--- a/.ai/agents/migration-agent.md
+++ b/.ai/agents/migration-agent.md
@@ -1,0 +1,5 @@
+<!-- agent-orchestrator:start -->
+# Migration Agent
+
+Treat migrations as versioned contracts. Provide a reversible migration, preserve existing data, validate ordering, and run the repository's discovered migration checks.
+<!-- agent-orchestrator:end -->

--- a/.ai/agents/reviewer.md
+++ b/.ai/agents/reviewer.md
@@ -1,0 +1,5 @@
+<!-- agent-orchestrator:start -->
+# Reviewer
+
+Review the real Git diff independently. Verify write scope, discovered commands, contracts, migrations, and evidence-backed acceptance criteria. Do not reuse the coder thread.
+<!-- agent-orchestrator:end -->

--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -1,0 +1,135 @@
+schema_version: 1
+stack:
+    - name: container
+      value: docker
+      confidence: 0.95
+      source_path: docker/Dockerfile
+      explanation: A Dockerfile defines a container build.
+    - name: framework
+      value: nats
+      confidence: 0.98
+      source_path: go.mod
+      explanation: go.mod declares dependency github.com/nats-io/nats.go.
+    - name: framework
+      value: pgx
+      confidence: 0.98
+      source_path: go.mod
+      explanation: go.mod declares dependency github.com/jackc/pgx.
+    - name: language
+      value: go
+      confidence: 1
+      source_path: go.mod
+      explanation: go.mod is the canonical Go module manifest.
+    - name: orchestration
+      value: docker_compose
+      confidence: 0.98
+      source_path: docker-compose.yml
+      explanation: A Docker Compose manifest defines local infrastructure or runtime services.
+ownership:
+    - name: database_table
+      value: permission
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: principal_override
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: principal_role
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: role_hierarchy
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: role_permission
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: role
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: service_permission
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: service_role
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: service
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: superadmin_principal
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+relations:
+    - name: depends_on
+      value: postgres
+      confidence: 0.9
+      source_path: docker-compose.yml
+      explanation: Docker Compose declares this service dependency.
+infrastructure:
+    - name: CACHE_TTL_SECONDS
+      value: 60 seconds default
+      confidence: 0.94
+      source_path: internal/config/config.go
+      explanation: Semantic proposal with a verified repository quote. Production configuration parses the cache TTL as seconds and defaults it to 60.
+    - name: NATS
+      value: Configured Core NATS request/reply broker
+      confidence: 0.94
+      source_path: internal/app/bootstrap.go
+      explanation: Semantic proposal with a verified repository quote. Production bootstrap connects to NATS when NATS_URL is nonempty and fails bootstrap if the connection cannot be established.
+    - name: PostgreSQL
+      value: Required runtime database
+      confidence: 0.95
+      source_path: internal/app/bootstrap.go
+      explanation: Semantic proposal with a verified repository quote. Production bootstrap code requires a working PostgreSQL pool before constructing repositories.
+    - name: compose_dependency
+      value: postgres service_healthy
+      confidence: 0.95
+      source_path: docker-compose.yml
+      explanation: Semantic proposal with a verified repository quote. The application Compose service waits for the PostgreSQL health condition.
+    - name: compose_service
+      value: msgo-rbac
+      confidence: 0.96
+      source_path: docker-compose.yml
+      explanation: Docker Compose declares this service.
+    - name: compose_service
+      value: postgres=postgres:16-alpine
+      confidence: 0.96
+      source_path: docker-compose.yml
+      explanation: Docker Compose declares this service.
+    - name: container_runtime
+      value: gcr.io/distroless/base-debian12; port 8080
+      confidence: 0.95
+      source_path: docker/Dockerfile
+      explanation: Semantic proposal with a verified repository quote. The runtime container uses a distroless Debian 12 base and exposes port 8080.
+    - name: network
+      value: ms-net
+      confidence: 0.95
+      source_path: docker-compose.yml
+      explanation: Semantic proposal with a verified repository quote. The Compose manifest declares an externally managed network.
+    - name: postgres
+      value: postgres:16-alpine
+      confidence: 0.95
+      source_path: docker-compose.yml
+      explanation: Semantic proposal with a verified repository quote. The Compose manifest declares a PostgreSQL service and image.
+    - name: runtime_configuration
+      value: HTTP_ADDR, DB_DSN, NATS_URL
+      confidence: 0.94
+      source_path: internal/config/config.go
+      explanation: Semantic proposal with a verified repository quote. Production configuration code identifies the HTTP, database, and NATS settings and their applicable defaults.

--- a/.ai/commands.yaml
+++ b/.ai/commands.yaml
@@ -1,0 +1,38 @@
+schema_version: 1
+commands:
+    - name: migrate_up
+      run: task migrate-up
+      source_path: README.md
+      confidence: 0.938
+      requires_approval: true
+      risk: state_change
+    - name: run_linter
+      run: golangci-lint run ./...
+      source_path: Taskfile.yml
+      confidence: 0.95
+      requires_approval: false
+      risk: verification
+    - name: run_service
+      run: go run ./cmd/ms-rbac-service
+      source_path: Taskfile.yml
+      confidence: 0.95
+      requires_approval: true
+      risk: lifecycle
+    - name: run_tests
+      run: go test ./...
+      source_path: Taskfile.yml
+      confidence: 0.95
+      requires_approval: false
+      risk: verification
+    - name: start_containers
+      run: docker compose up -d
+      source_path: Taskfile.yml
+      confidence: 0.95
+      requires_approval: true
+      risk: external_runtime
+    - name: stop_containers
+      run: docker compose down
+      source_path: Taskfile.yml
+      confidence: 0.95
+      requires_approval: true
+      risk: state_change

--- a/.ai/contracts/database.yaml
+++ b/.ai/contracts/database.yaml
@@ -1,0 +1,72 @@
+schema_version: 1
+contracts:
+    - name: database_schema
+      value: 'default roles: admin, moderator, teacher, student, user, guest'
+      confidence: 0.95
+      source_path: migrations/002_seed_default_roles_and_principals.up.sql
+      explanation: Semantic proposal with a verified repository quote. Checked-in migration SQL seeds these role keys.
+    - name: database_schema
+      value: migrations/001_init.sql
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: The SQL file creates database resources owned by the project.
+    - name: database_schema
+      value: override_effect=allow|deny
+      confidence: 0.95
+      source_path: migrations/001_init.sql
+      explanation: Semantic proposal with a verified repository quote. Checked-in SQL defines the allowed override effects.
+    - name: database_schema
+      value: principal_kind=user|service_account|group
+      confidence: 0.95
+      source_path: migrations/001_init.sql
+      explanation: Semantic proposal with a verified repository quote. Checked-in SQL defines the allowed principal kinds.
+    - name: database_table
+      value: permission
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: principal_override
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: principal_role
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: role_hierarchy
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: role_permission
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: role
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: service_permission
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: service_role
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: service
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: superadmin_principal
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.

--- a/.ai/contracts/events.yaml
+++ b/.ai/contracts/events.yaml
@@ -1,0 +1,22 @@
+schema_version: 1
+contracts:
+    - name: event_subject
+      value: rbac.assign-role
+      confidence: 0.72
+      source_path: README.md
+      explanation: A NATS/event-related source line references this subject.
+    - name: event_subject
+      value: rbac.assign-role
+      confidence: 0.72
+      source_path: internal/app/bootstrap.go
+      explanation: A NATS/event-related source line references this subject.
+    - name: event_subject
+      value: rbac.checkRole
+      confidence: 0.72
+      source_path: README.md
+      explanation: A NATS/event-related source line references this subject.
+    - name: event_subject
+      value: rbac.checkRole
+      confidence: 0.72
+      source_path: internal/app/bootstrap.go
+      explanation: A NATS/event-related source line references this subject.

--- a/.ai/contracts/http.yaml
+++ b/.ai/contracts/http.yaml
@@ -1,0 +1,152 @@
+schema_version: 1
+contracts:
+    - name: http_route
+      value: ANY /permission-list
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /permission/
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /permission
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /principal-permission/get-by-permission
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /principal-permission/list
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /principal-role/get-by-role
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /principal-role/get
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /principal-role/update
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /role-list
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /role-permission
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /role/
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /role
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /service-list
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /service/
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /service
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: GET /admin/v1/permission-list
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/admin.go
+      explanation: Semantic proposal with a verified repository quote. The production permission-list handler only accepts GET.
+    - name: http_route
+      value: GET /admin/v1/role-list
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/admin.go
+      explanation: Semantic proposal with a verified repository quote. The production role-list handler only accepts GET.
+    - name: http_route
+      value: GET /admin/v1/service-list
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/admin.go
+      explanation: Semantic proposal with a verified repository quote. The production list handler only accepts GET.
+    - name: http_route
+      value: GET /api/v1/principal-permission/get-by-permission
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/api.go
+      explanation: Semantic proposal with a verified repository quote. The production permission-check handler only accepts GET.
+    - name: http_route
+      value: GET /api/v1/principal-permission/list
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/api.go
+      explanation: Semantic proposal with a verified repository quote. The production principal-permission list handler only accepts GET.
+    - name: http_route
+      value: GET /api/v1/principal-role/get-by-role
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/api.go
+      explanation: Semantic proposal with a verified repository quote. The production role-check handler only accepts GET.
+    - name: http_route
+      value: GET /api/v1/principal-role/get
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/api.go
+      explanation: Semantic proposal with a verified repository quote. The production principal-role lookup handler only accepts GET.
+    - name: http_route
+      value: GET|PUT /admin/v1/permission/{id}
+      confidence: 0.95
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: Semantic proposal with a verified repository quote. The admin router registers GET and PUT permission handlers on the identifier path.
+    - name: http_route
+      value: GET|PUT /admin/v1/role/{id}
+      confidence: 0.95
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: Semantic proposal with a verified repository quote. The admin router registers GET and PUT role handlers on the identifier path.
+    - name: http_route
+      value: GET|PUT /admin/v1/service/{id}
+      confidence: 0.95
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: Semantic proposal with a verified repository quote. The admin router registers GET and PUT service handlers on the identifier path.
+    - name: http_route
+      value: PATCH /api/v1/principal-role/update
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/api.go
+      explanation: Semantic proposal with a verified repository quote. The production principal-role update handler only accepts PATCH.
+    - name: http_route
+      value: POST /admin/v1/role-permission
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/admin.go
+      explanation: Semantic proposal with a verified repository quote. The production role-permission assignment handler only accepts POST.
+    - name: http_route
+      value: SET /admin/v1/permission
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/admin.go
+      explanation: Semantic proposal with a verified repository quote. The production handler accepts the nonstandard SET method for permission creation.
+    - name: http_route
+      value: SET /admin/v1/role
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/admin.go
+      explanation: Semantic proposal with a verified repository quote. The production handler accepts the nonstandard SET method for role creation.
+    - name: http_route
+      value: SET /admin/v1/service
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/admin.go
+      explanation: Semantic proposal with a verified repository quote. The production handler accepts the nonstandard SET method for service creation.

--- a/.ai/discovery/latest-report.json
+++ b/.ai/discovery/latest-report.json
@@ -1,0 +1,880 @@
+{
+  "schema_version": 16,
+  "project_id": "0286f605-06f9-4500-8530-56a7eed20763",
+  "project_name": "ms-go-rbac",
+  "repository_role": "service",
+  "repository_path": ".",
+  "commit_sha": "ca10bb399b11ab2a7c19a83b960d90165b7dcd6c",
+  "branch": "main",
+  "is_dirty": false,
+  "content_checksum": "cdca68d85e39f86cf6d4d30df59c70fb8d86e63cf652ec9aa9f7a14b39d998a0",
+  "started_at": "2026-07-23T05:32:14.221487376Z",
+  "completed_at": "2026-07-23T05:32:14.231841501Z",
+  "inventory": {
+    "files_visited": 48,
+    "files_analyzed": 45,
+    "bytes_analyzed": 118586,
+    "content_checksum": "cdca68d85e39f86cf6d4d30df59c70fb8d86e63cf652ec9aa9f7a14b39d998a0",
+    "truncated": false,
+    "excluded_paths": 1,
+    "skipped_large_files": 0
+  },
+  "facts": [
+    {
+      "category": "business_rule",
+      "name": "permission_identifier_format",
+      "value": "action:resource_kind",
+      "confidence": 0.93,
+      "source_path": "internal/usecase/principal.go",
+      "explanation": "Semantic proposal with a verified repository quote. Production use-case code defines the combined permission identifier format."
+    },
+    {
+      "category": "business_rule",
+      "name": "principal_permission_match",
+      "value": "Permission checks use exact identifier equality",
+      "confidence": 0.94,
+      "source_path": "internal/usecase/principal.go",
+      "explanation": "Semantic proposal with a verified repository quote. A permission check succeeds only when the requested identifier exactly matches one resolved identifier."
+    },
+    {
+      "category": "business_rule",
+      "name": "principal_role_assignment_idempotency",
+      "value": "Reassigning the same existing role succeeds without a database update",
+      "confidence": 0.94,
+      "source_path": "internal/usecase/principal.go",
+      "explanation": "Semantic proposal with a verified repository quote. Production use-case code makes repeated assignment of the current nonempty role a no-op."
+    },
+    {
+      "category": "business_rule",
+      "name": "principal_role_match",
+      "value": "Role checks require an exact nonempty role match",
+      "confidence": 0.94,
+      "source_path": "internal/usecase/principal.go",
+      "explanation": "Semantic proposal with a verified repository quote. A role check succeeds only when the stored role equals the trimmed requested role and is nonempty."
+    },
+    {
+      "category": "capability",
+      "name": "business capability",
+      "value": "Versioned RBAC administration API",
+      "confidence": 0.93,
+      "source_path": "internal/adapters/http/router.go",
+      "explanation": "Semantic proposal with a verified repository quote. Production routing code mounts the administrative API beneath this prefix."
+    },
+    {
+      "category": "capability",
+      "name": "business capability",
+      "value": "Versioned principal role and permission API",
+      "confidence": 0.93,
+      "source_path": "internal/adapters/http/router.go",
+      "explanation": "Semantic proposal with a verified repository quote. Production routing code mounts the client API beneath this prefix."
+    },
+    {
+      "category": "capability",
+      "name": "event_subject",
+      "value": "rbac.assign-role",
+      "confidence": 0.72,
+      "source_path": "README.md",
+      "explanation": "A NATS/event-related source line references this subject."
+    },
+    {
+      "category": "capability",
+      "name": "event_subject",
+      "value": "rbac.assign-role",
+      "confidence": 0.72,
+      "source_path": "internal/app/bootstrap.go",
+      "explanation": "A NATS/event-related source line references this subject."
+    },
+    {
+      "category": "capability",
+      "name": "event_subject",
+      "value": "rbac.checkRole",
+      "confidence": 0.72,
+      "source_path": "README.md",
+      "explanation": "A NATS/event-related source line references this subject."
+    },
+    {
+      "category": "capability",
+      "name": "event_subject",
+      "value": "rbac.checkRole",
+      "confidence": 0.72,
+      "source_path": "internal/app/bootstrap.go",
+      "explanation": "A NATS/event-related source line references this subject."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /permission-list",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /permission/",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /permission",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /principal-permission/get-by-permission",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/api/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /principal-permission/list",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/api/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /principal-role/get-by-role",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/api/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /principal-role/get",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/api/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /principal-role/update",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/api/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /role-list",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /role-permission",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /role/",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /role",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /service-list",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /service/",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "ANY /service",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "A net/http HandleFunc registration exposes this route without a single-method guard."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET /admin/v1/permission-list",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/admin.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production permission-list handler only accepts GET."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET /admin/v1/role-list",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/admin.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production role-list handler only accepts GET."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET /admin/v1/service-list",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/admin.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production list handler only accepts GET."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET /api/v1/principal-permission/get-by-permission",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/api.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production permission-check handler only accepts GET."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET /api/v1/principal-permission/list",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/api.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production principal-permission list handler only accepts GET."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET /api/v1/principal-role/get-by-role",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/api.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production role-check handler only accepts GET."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET /api/v1/principal-role/get",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/api.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production principal-role lookup handler only accepts GET."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET|PUT /admin/v1/permission/{id}",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "Semantic proposal with a verified repository quote. The admin router registers GET and PUT permission handlers on the identifier path."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET|PUT /admin/v1/role/{id}",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "Semantic proposal with a verified repository quote. The admin router registers GET and PUT role handlers on the identifier path."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET|PUT /admin/v1/service/{id}",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "Semantic proposal with a verified repository quote. The admin router registers GET and PUT service handlers on the identifier path."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "PATCH /api/v1/principal-role/update",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/api.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production principal-role update handler only accepts PATCH."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "POST /admin/v1/role-permission",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/admin.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production role-permission assignment handler only accepts POST."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "SET /admin/v1/permission",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/admin.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production handler accepts the nonstandard SET method for permission creation."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "SET /admin/v1/role",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/admin.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production handler accepts the nonstandard SET method for role creation."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "SET /admin/v1/service",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/admin.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production handler accepts the nonstandard SET method for service creation."
+    },
+    {
+      "category": "classification",
+      "name": "service_kind",
+      "value": "backend_service",
+      "confidence": 0.8,
+      "source_path": ".",
+      "explanation": "Detected runtime source or manifests identify a backend service, with no stronger specialized kind signal."
+    },
+    {
+      "category": "command",
+      "name": "migrate_up",
+      "value": "task migrate-up",
+      "confidence": 0.938,
+      "source_path": "README.md",
+      "explanation": "Semantic proposal with a verified repository quote. The README documents the migration task invocation, and Taskfile.yml defines migrate-up."
+    },
+    {
+      "category": "command",
+      "name": "run_linter",
+      "value": "golangci-lint run ./...",
+      "confidence": 0.95,
+      "source_path": "Taskfile.yml",
+      "explanation": "Semantic proposal with a verified repository quote. The Taskfile documents this local lint command."
+    },
+    {
+      "category": "command",
+      "name": "run_service",
+      "value": "go run ./cmd/ms-rbac-service",
+      "confidence": 0.95,
+      "source_path": "Taskfile.yml",
+      "explanation": "Semantic proposal with a verified repository quote. The Taskfile documents this local service command, and go.mod provides the Go runtime manifest."
+    },
+    {
+      "category": "command",
+      "name": "run_tests",
+      "value": "go test ./...",
+      "confidence": 0.95,
+      "source_path": "Taskfile.yml",
+      "explanation": "Semantic proposal with a verified repository quote. The Taskfile documents this local test command, and go.mod provides the Go runtime manifest."
+    },
+    {
+      "category": "command",
+      "name": "start_containers",
+      "value": "docker compose up -d",
+      "confidence": 0.95,
+      "source_path": "Taskfile.yml",
+      "explanation": "Semantic proposal with a verified repository quote. The Taskfile documents this developer-facing container startup command."
+    },
+    {
+      "category": "command",
+      "name": "stop_containers",
+      "value": "docker compose down",
+      "confidence": 0.95,
+      "source_path": "Taskfile.yml",
+      "explanation": "Semantic proposal with a verified repository quote. The Taskfile documents this developer-facing container shutdown command."
+    },
+    {
+      "category": "contract",
+      "name": "database_schema",
+      "value": "default roles: admin, moderator, teacher, student, user, guest",
+      "confidence": 0.95,
+      "source_path": "migrations/002_seed_default_roles_and_principals.up.sql",
+      "explanation": "Semantic proposal with a verified repository quote. Checked-in migration SQL seeds these role keys."
+    },
+    {
+      "category": "contract",
+      "name": "database_schema",
+      "value": "migrations/001_init.sql",
+      "confidence": 0.96,
+      "source_path": "migrations/001_init.sql",
+      "explanation": "The SQL file creates database resources owned by the project."
+    },
+    {
+      "category": "contract",
+      "name": "database_schema",
+      "value": "override_effect=allow|deny",
+      "confidence": 0.95,
+      "source_path": "migrations/001_init.sql",
+      "explanation": "Semantic proposal with a verified repository quote. Checked-in SQL defines the allowed override effects."
+    },
+    {
+      "category": "contract",
+      "name": "database_schema",
+      "value": "principal_kind=user|service_account|group",
+      "confidence": 0.95,
+      "source_path": "migrations/001_init.sql",
+      "explanation": "Semantic proposal with a verified repository quote. Checked-in SQL defines the allowed principal kinds."
+    },
+    {
+      "category": "contract",
+      "name": "event_publish",
+      "value": "rbac.assign-role reply: ok, error",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/nats/role_assigner.go",
+      "explanation": "Semantic proposal with a verified repository quote. Production subscriber code defines the request/reply response payload."
+    },
+    {
+      "category": "contract",
+      "name": "event_publish",
+      "value": "rbac.checkRole reply: ok, error",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/nats/role_checker.go",
+      "explanation": "Semantic proposal with a verified repository quote. Production subscriber code defines the role-check reply payload."
+    },
+    {
+      "category": "contract",
+      "name": "event_subscribe",
+      "value": "rbac.assign-role request: user_id, role",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/nats/role_assigner.go",
+      "explanation": "Semantic proposal with a verified repository quote. Production subscriber code defines the request payload for role assignment."
+    },
+    {
+      "category": "contract",
+      "name": "event_subscribe",
+      "value": "rbac.assign-role",
+      "confidence": 0.95,
+      "source_path": "internal/app/bootstrap.go",
+      "explanation": "Semantic proposal with a verified repository quote. Production bootstrap code configures a queue subscriber for the role-assignment subject."
+    },
+    {
+      "category": "contract",
+      "name": "event_subscribe",
+      "value": "rbac.checkRole request: user_id, role",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/nats/role_checker.go",
+      "explanation": "Semantic proposal with a verified repository quote. Production subscriber code defines the role-check request payload."
+    },
+    {
+      "category": "contract",
+      "name": "event_subscribe",
+      "value": "rbac.checkRole",
+      "confidence": 0.95,
+      "source_path": "internal/app/bootstrap.go",
+      "explanation": "Semantic proposal with a verified repository quote. Production bootstrap code configures a queue subscriber for the role-check subject."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /permission-list",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /permission/",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /permission",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /principal-permission/get-by-permission",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/api/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /principal-permission/list",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/api/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /principal-role/get-by-role",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/api/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /principal-role/get",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/api/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /principal-role/update",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/api/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /role-list",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /role-permission",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /role/",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /role",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /service-list",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /service/",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "contract",
+      "name": "http_produce",
+      "value": "ANY /service",
+      "confidence": 0.72,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "explanation": "The service implementation provides this HTTP contract."
+    },
+    {
+      "category": "entity",
+      "name": "permission",
+      "value": "Permission",
+      "confidence": 0.92,
+      "source_path": "internal/domain/model/models.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production domain model defines the Permission entity."
+    },
+    {
+      "category": "entity",
+      "name": "principal_override",
+      "value": "PrincipalOverride",
+      "confidence": 0.938,
+      "source_path": "internal/domain/model/models.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production domain model defines principal permission overrides."
+    },
+    {
+      "category": "entity",
+      "name": "principal_role",
+      "value": "PrincipalRole",
+      "confidence": 0.938,
+      "source_path": "internal/domain/model/models.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production domain model defines scoped principal-role assignments."
+    },
+    {
+      "category": "entity",
+      "name": "role",
+      "value": "Role",
+      "confidence": 0.92,
+      "source_path": "internal/domain/model/models.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production domain model defines the Role entity."
+    },
+    {
+      "category": "entity",
+      "name": "service",
+      "value": "Service",
+      "confidence": 0.92,
+      "source_path": "internal/domain/model/models.go",
+      "explanation": "Semantic proposal with a verified repository quote. The production domain model defines the Service entity."
+    },
+    {
+      "category": "infrastructure",
+      "name": "CACHE_TTL_SECONDS",
+      "value": "60 seconds default",
+      "confidence": 0.94,
+      "source_path": "internal/config/config.go",
+      "explanation": "Semantic proposal with a verified repository quote. Production configuration parses the cache TTL as seconds and defaults it to 60."
+    },
+    {
+      "category": "infrastructure",
+      "name": "NATS",
+      "value": "Configured Core NATS request/reply broker",
+      "confidence": 0.94,
+      "source_path": "internal/app/bootstrap.go",
+      "explanation": "Semantic proposal with a verified repository quote. Production bootstrap connects to NATS when NATS_URL is nonempty and fails bootstrap if the connection cannot be established."
+    },
+    {
+      "category": "infrastructure",
+      "name": "PostgreSQL",
+      "value": "Required runtime database",
+      "confidence": 0.95,
+      "source_path": "internal/app/bootstrap.go",
+      "explanation": "Semantic proposal with a verified repository quote. Production bootstrap code requires a working PostgreSQL pool before constructing repositories."
+    },
+    {
+      "category": "infrastructure",
+      "name": "compose_dependency",
+      "value": "postgres service_healthy",
+      "confidence": 0.95,
+      "source_path": "docker-compose.yml",
+      "explanation": "Semantic proposal with a verified repository quote. The application Compose service waits for the PostgreSQL health condition."
+    },
+    {
+      "category": "infrastructure",
+      "name": "compose_service",
+      "value": "msgo-rbac",
+      "confidence": 0.96,
+      "source_path": "docker-compose.yml",
+      "explanation": "Docker Compose declares this service."
+    },
+    {
+      "category": "infrastructure",
+      "name": "compose_service",
+      "value": "postgres=postgres:16-alpine",
+      "confidence": 0.96,
+      "source_path": "docker-compose.yml",
+      "explanation": "Docker Compose declares this service."
+    },
+    {
+      "category": "infrastructure",
+      "name": "container_runtime",
+      "value": "gcr.io/distroless/base-debian12; port 8080",
+      "confidence": 0.95,
+      "source_path": "docker/Dockerfile",
+      "explanation": "Semantic proposal with a verified repository quote. The runtime container uses a distroless Debian 12 base and exposes port 8080."
+    },
+    {
+      "category": "infrastructure",
+      "name": "network",
+      "value": "ms-net",
+      "confidence": 0.95,
+      "source_path": "docker-compose.yml",
+      "explanation": "Semantic proposal with a verified repository quote. The Compose manifest declares an externally managed network."
+    },
+    {
+      "category": "infrastructure",
+      "name": "postgres",
+      "value": "postgres:16-alpine",
+      "confidence": 0.95,
+      "source_path": "docker-compose.yml",
+      "explanation": "Semantic proposal with a verified repository quote. The Compose manifest declares a PostgreSQL service and image."
+    },
+    {
+      "category": "infrastructure",
+      "name": "runtime_configuration",
+      "value": "HTTP_ADDR, DB_DSN, NATS_URL",
+      "confidence": 0.94,
+      "source_path": "internal/config/config.go",
+      "explanation": "Semantic proposal with a verified repository quote. Production configuration code identifies the HTTP, database, and NATS settings and their applicable defaults."
+    },
+    {
+      "category": "instruction",
+      "name": "instruction_file",
+      "value": "185314f18937de6dd189e3b1242c85d2c7dd6b0c6ac233652d421f5fbc715bca",
+      "confidence": 0.98,
+      "source_path": "AGENTS.md",
+      "explanation": "The file contains repository or agent instructions; only its checksum is collected."
+    },
+    {
+      "category": "instruction",
+      "name": "instruction_file",
+      "value": "ad38d49dc0d8ea99da6d71951b8b449c776c59ba642db1cfa5c310d5f4fc39c5",
+      "confidence": 0.98,
+      "source_path": "prompts/git-workflow.md",
+      "explanation": "The file contains repository or agent instructions; only its checksum is collected."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "permission",
+      "confidence": 0.96,
+      "source_path": "migrations/001_init.sql",
+      "explanation": "A checked-in SQL schema file creates this table, indicating schema ownership."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "principal_override",
+      "confidence": 0.96,
+      "source_path": "migrations/001_init.sql",
+      "explanation": "A checked-in SQL schema file creates this table, indicating schema ownership."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "principal_role",
+      "confidence": 0.96,
+      "source_path": "migrations/001_init.sql",
+      "explanation": "A checked-in SQL schema file creates this table, indicating schema ownership."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "role_hierarchy",
+      "confidence": 0.96,
+      "source_path": "migrations/001_init.sql",
+      "explanation": "A checked-in SQL schema file creates this table, indicating schema ownership."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "role_permission",
+      "confidence": 0.96,
+      "source_path": "migrations/001_init.sql",
+      "explanation": "A checked-in SQL schema file creates this table, indicating schema ownership."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "role",
+      "confidence": 0.96,
+      "source_path": "migrations/001_init.sql",
+      "explanation": "A checked-in SQL schema file creates this table, indicating schema ownership."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "service_permission",
+      "confidence": 0.96,
+      "source_path": "migrations/001_init.sql",
+      "explanation": "A checked-in SQL schema file creates this table, indicating schema ownership."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "service_role",
+      "confidence": 0.96,
+      "source_path": "migrations/001_init.sql",
+      "explanation": "A checked-in SQL schema file creates this table, indicating schema ownership."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "service",
+      "confidence": 0.96,
+      "source_path": "migrations/001_init.sql",
+      "explanation": "A checked-in SQL schema file creates this table, indicating schema ownership."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "superadmin_principal",
+      "confidence": 0.96,
+      "source_path": "migrations/001_init.sql",
+      "explanation": "A checked-in SQL schema file creates this table, indicating schema ownership."
+    },
+    {
+      "category": "purpose",
+      "name": "summary",
+      "value": "Go RBAC microservice for services, roles, permissions, and principal assignments",
+      "confidence": 0.901,
+      "source_path": "README.md",
+      "explanation": "Semantic proposal with a verified repository quote. The README directly identifies the repository as a Go RBAC microservice and summarizes its administrative scope."
+    },
+    {
+      "category": "purpose",
+      "name": "summary",
+      "value": "This repository provides a lightweight RBAC microservice implemented in Go. The service exposes administrative HTTP endpoints for managing services, roles, permissions, and principal assignments. Data is stored in Postgres via the migrations in `migrations/`, which keeps role assignments persistent across restarts.",
+      "confidence": 0.85,
+      "source_path": "README.md",
+      "explanation": "The first prose paragraph in the root README describes the repository purpose."
+    },
+    {
+      "category": "relation",
+      "name": "depends_on",
+      "value": "postgres",
+      "confidence": 0.9,
+      "source_path": "docker-compose.yml",
+      "explanation": "Docker Compose declares this service dependency."
+    },
+    {
+      "category": "stack",
+      "name": "container",
+      "value": "docker",
+      "confidence": 0.95,
+      "source_path": "docker/Dockerfile",
+      "explanation": "A Dockerfile defines a container build."
+    },
+    {
+      "category": "stack",
+      "name": "framework",
+      "value": "nats",
+      "confidence": 0.98,
+      "source_path": "go.mod",
+      "explanation": "go.mod declares dependency github.com/nats-io/nats.go."
+    },
+    {
+      "category": "stack",
+      "name": "framework",
+      "value": "pgx",
+      "confidence": 0.98,
+      "source_path": "go.mod",
+      "explanation": "go.mod declares dependency github.com/jackc/pgx."
+    },
+    {
+      "category": "stack",
+      "name": "language",
+      "value": "go",
+      "confidence": 1,
+      "source_path": "go.mod",
+      "explanation": "go.mod is the canonical Go module manifest."
+    },
+    {
+      "category": "stack",
+      "name": "orchestration",
+      "value": "docker_compose",
+      "confidence": 0.98,
+      "source_path": "docker-compose.yml",
+      "explanation": "A Docker Compose manifest defines local infrastructure or runtime services."
+    }
+  ]
+}

--- a/.ai/discovery/semantic-report.json
+++ b/.ai/discovery/semantic-report.json
@@ -1,0 +1,622 @@
+{
+  "schema_version": 1,
+  "project_id": "0286f605-06f9-4500-8530-56a7eed20763",
+  "project_name": "ms-go-rbac",
+  "base_commit": "ca10bb399b11ab2a7c19a83b960d90165b7dcd6c",
+  "summary": "The repository implements a Go RBAC backend with versioned administrative and principal-facing HTTP APIs, PostgreSQL persistence, and Core NATS request/reply handlers for role assignment and role checking. Checked-in SQL owns ten tables and seeds six default roles. Local operation is defined through Docker Compose, a Taskfile, and a distroless production container. No supported direct runtime relation to a named connected project or CI pipeline was established.",
+  "facts": [
+    {
+      "category": "business_rule",
+      "name": "permission_identifier_format",
+      "value": "action:resource_kind",
+      "confidence": 0.93,
+      "source_path": "internal/usecase/principal.go",
+      "evidence_quote": "case perm.Action != \"\" \u0026\u0026 perm.ResourceKind != \"\":\n\t\treturn perm.Action + \":\" + perm.ResourceKind",
+      "explanation": "Production use-case code defines the combined permission identifier format."
+    },
+    {
+      "category": "business_rule",
+      "name": "principal_permission_match",
+      "value": "Permission checks use exact identifier equality",
+      "confidence": 0.94,
+      "source_path": "internal/usecase/principal.go",
+      "evidence_quote": "for _, p := range perms {\n\t\tif p == permission {\n\t\t\treturn true, nil\n\t\t}\n\t}\n\treturn false, nil",
+      "explanation": "A permission check succeeds only when the requested identifier exactly matches one resolved identifier."
+    },
+    {
+      "category": "business_rule",
+      "name": "principal_role_assignment_idempotency",
+      "value": "Reassigning the same existing role succeeds without a database update",
+      "confidence": 0.94,
+      "source_path": "internal/usecase/principal.go",
+      "evidence_quote": "current, err := uc.repo.Get(ctx, principalID)\n\tif err != nil {\n\t\treturn err\n\t}\n\tif current == input.RoleKey \u0026\u0026 current != \"\" {\n\t\treturn nil\n\t}",
+      "explanation": "Production use-case code makes repeated assignment of the current nonempty role a no-op."
+    },
+    {
+      "category": "business_rule",
+      "name": "principal_role_match",
+      "value": "Role checks require an exact nonempty role match",
+      "confidence": 0.94,
+      "source_path": "internal/usecase/principal.go",
+      "evidence_quote": "role = strings.TrimSpace(role)\n\treturn current == role \u0026\u0026 current != \"\", nil",
+      "explanation": "A role check succeeds only when the stored role equals the trimmed requested role and is nonempty."
+    },
+    {
+      "category": "capability",
+      "name": "business capability",
+      "value": "Versioned RBAC administration API",
+      "confidence": 0.93,
+      "source_path": "internal/adapters/http/router.go",
+      "evidence_quote": "adminMux := http.NewServeMux()\n\tadminv1.RegisterRoutes(adminMux, r.adminHandlers)\n\tmux.Handle(\"/admin/v1/\", http.StripPrefix(\"/admin/v1\", adminMux))",
+      "explanation": "Production routing code mounts the administrative API beneath this prefix."
+    },
+    {
+      "category": "capability",
+      "name": "business capability",
+      "value": "Versioned principal role and permission API",
+      "confidence": 0.93,
+      "source_path": "internal/adapters/http/router.go",
+      "evidence_quote": "apiMux := http.NewServeMux()\n\tapiv1.RegisterRoutes(apiMux, r.apiHandlers)\n\tmux.Handle(\"/api/v1/\", http.StripPrefix(\"/api/v1\", apiMux))",
+      "explanation": "Production routing code mounts the client API beneath this prefix."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET /admin/v1/permission-list",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/admin.go",
+      "evidence_quote": "func (h *PermissionHandler) List(w http.ResponseWriter, r *http.Request) {\n\tif r.Method != http.MethodGet {\n\t\thttp.NotFound(w, r)",
+      "explanation": "The production permission-list handler only accepts GET."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET /admin/v1/role-list",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/admin.go",
+      "evidence_quote": "func (h *RoleHandler) List(w http.ResponseWriter, r *http.Request) {\n\tif r.Method != http.MethodGet {\n\t\thttp.NotFound(w, r)",
+      "explanation": "The production role-list handler only accepts GET."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET /admin/v1/service-list",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/admin.go",
+      "evidence_quote": "func (h *ServiceHandler) List(w http.ResponseWriter, r *http.Request) {\n\tif r.Method != http.MethodGet {\n\t\thttp.NotFound(w, r)",
+      "explanation": "The production list handler only accepts GET."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET /api/v1/principal-permission/get-by-permission",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/api.go",
+      "evidence_quote": "func (h *PrincipalPermissionHandler) GetByPermission(w http.ResponseWriter, r *http.Request) {\n\tif r.Method != http.MethodGet {\n\t\thttp.NotFound(w, r)",
+      "explanation": "The production permission-check handler only accepts GET."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET /api/v1/principal-permission/list",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/api.go",
+      "evidence_quote": "func (h *PrincipalPermissionHandler) List(w http.ResponseWriter, r *http.Request) {\n\tif r.Method != http.MethodGet {\n\t\thttp.NotFound(w, r)",
+      "explanation": "The production principal-permission list handler only accepts GET."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET /api/v1/principal-role/get-by-role",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/api.go",
+      "evidence_quote": "func (h *PrincipalRoleHandler) GetByRole(w http.ResponseWriter, r *http.Request) {\n\tif r.Method != http.MethodGet {\n\t\thttp.NotFound(w, r)",
+      "explanation": "The production role-check handler only accepts GET."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET /api/v1/principal-role/get",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/api.go",
+      "evidence_quote": "func (h *PrincipalRoleHandler) Get(w http.ResponseWriter, r *http.Request) {\n\tif r.Method != http.MethodGet {\n\t\thttp.NotFound(w, r)",
+      "explanation": "The production principal-role lookup handler only accepts GET."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET|PUT /admin/v1/permission/{id}",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "evidence_quote": "mux.HandleFunc(\"/permission/\", methodMux(map[string]http.HandlerFunc{\n\t\thttp.MethodGet: h.Permission.Get,\n\t\thttp.MethodPut: h.Permission.Update,\n\t}))",
+      "explanation": "The admin router registers GET and PUT permission handlers on the identifier path."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET|PUT /admin/v1/role/{id}",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "evidence_quote": "mux.HandleFunc(\"/role/\", methodMux(map[string]http.HandlerFunc{\n\t\thttp.MethodGet: h.Role.Get,\n\t\thttp.MethodPut: h.Role.Update,\n\t}))",
+      "explanation": "The admin router registers GET and PUT role handlers on the identifier path."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "GET|PUT /admin/v1/service/{id}",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/admin/v1/router.go",
+      "evidence_quote": "mux.HandleFunc(\"/service/\", methodMux(map[string]http.HandlerFunc{\n\t\thttp.MethodGet: h.Service.Get,\n\t\thttp.MethodPut: h.Service.Update,\n\t}))",
+      "explanation": "The admin router registers GET and PUT service handlers on the identifier path."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "PATCH /api/v1/principal-role/update",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/api.go",
+      "evidence_quote": "func (h *PrincipalRoleHandler) Update(w http.ResponseWriter, r *http.Request) {\n\tif r.Method != http.MethodPatch {\n\t\thttp.NotFound(w, r)",
+      "explanation": "The production principal-role update handler only accepts PATCH."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "POST /admin/v1/role-permission",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/admin.go",
+      "evidence_quote": "func (h *RolePermissionHandler) Create(w http.ResponseWriter, r *http.Request) {\n\tif r.Method != http.MethodPost {\n\t\thttp.NotFound(w, r)",
+      "explanation": "The production role-permission assignment handler only accepts POST."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "SET /admin/v1/permission",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/admin.go",
+      "evidence_quote": "func (h *PermissionHandler) Create(w http.ResponseWriter, r *http.Request) {\n\tif r.Method != \"SET\" {\n\t\thttp.NotFound(w, r)",
+      "explanation": "The production handler accepts the nonstandard SET method for permission creation."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "SET /admin/v1/role",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/admin.go",
+      "evidence_quote": "func (h *RoleHandler) Create(w http.ResponseWriter, r *http.Request) {\n\tif r.Method != \"SET\" {\n\t\thttp.NotFound(w, r)",
+      "explanation": "The production handler accepts the nonstandard SET method for role creation."
+    },
+    {
+      "category": "capability",
+      "name": "http_route",
+      "value": "SET /admin/v1/service",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/http/handlers/admin.go",
+      "evidence_quote": "func (h *ServiceHandler) Create(w http.ResponseWriter, r *http.Request) {\n\tif r.Method != \"SET\" {\n\t\thttp.NotFound(w, r)",
+      "explanation": "The production handler accepts the nonstandard SET method for service creation."
+    },
+    {
+      "category": "command",
+      "name": "migrate_up",
+      "value": "task migrate-up",
+      "confidence": 0.938,
+      "source_path": "README.md",
+      "evidence_quote": "docker compose up -d\ntask migrate-up\ngo run ./cmd/ms-rbac-service",
+      "explanation": "The README documents the migration task invocation, and Taskfile.yml defines migrate-up."
+    },
+    {
+      "category": "command",
+      "name": "run_linter",
+      "value": "golangci-lint run ./...",
+      "confidence": 0.95,
+      "source_path": "Taskfile.yml",
+      "evidence_quote": "lint:\n    desc: Run linter\n    cmds:\n      - golangci-lint run ./...",
+      "explanation": "The Taskfile documents this local lint command."
+    },
+    {
+      "category": "command",
+      "name": "run_service",
+      "value": "go run ./cmd/ms-rbac-service",
+      "confidence": 0.95,
+      "source_path": "Taskfile.yml",
+      "evidence_quote": "run:\n    desc: Run service locally\n    cmds:\n      - go run ./cmd/ms-rbac-service",
+      "explanation": "The Taskfile documents this local service command, and go.mod provides the Go runtime manifest."
+    },
+    {
+      "category": "command",
+      "name": "run_tests",
+      "value": "go test ./...",
+      "confidence": 0.95,
+      "source_path": "Taskfile.yml",
+      "evidence_quote": "test:\n    desc: Run tests\n    cmds:\n      - go test ./...",
+      "explanation": "The Taskfile documents this local test command, and go.mod provides the Go runtime manifest."
+    },
+    {
+      "category": "command",
+      "name": "start_containers",
+      "value": "docker compose up -d",
+      "confidence": 0.95,
+      "source_path": "Taskfile.yml",
+      "evidence_quote": "up:\n    desc: Start containers\n    cmds:\n      - docker compose up -d",
+      "explanation": "The Taskfile documents this developer-facing container startup command."
+    },
+    {
+      "category": "command",
+      "name": "stop_containers",
+      "value": "docker compose down",
+      "confidence": 0.95,
+      "source_path": "Taskfile.yml",
+      "evidence_quote": "down:\n    desc: Stop containers\n    cmds:\n      - docker compose down",
+      "explanation": "The Taskfile documents this developer-facing container shutdown command."
+    },
+    {
+      "category": "contract",
+      "name": "database_schema",
+      "value": "default roles: admin, moderator, teacher, student, user, guest",
+      "confidence": 0.95,
+      "source_path": "migrations/002_seed_default_roles_and_principals.up.sql",
+      "evidence_quote": "INSERT INTO role (key, title)\nVALUES\n    ('admin', 'Admin'),\n    ('moderator', 'Moderator'),\n    ('teacher', 'Teacher'),\n    ('student', 'Student'),\n    ('user', 'User'),\n    ('guest', 'Guest')",
+      "explanation": "Checked-in migration SQL seeds these role keys."
+    },
+    {
+      "category": "contract",
+      "name": "database_schema",
+      "value": "override_effect=allow|deny",
+      "confidence": 0.95,
+      "source_path": "migrations/001_init.sql",
+      "evidence_quote": "create type override_effect as enum ('allow','deny');",
+      "explanation": "Checked-in SQL defines the allowed override effects."
+    },
+    {
+      "category": "contract",
+      "name": "database_schema",
+      "value": "principal_kind=user|service_account|group",
+      "confidence": 0.95,
+      "source_path": "migrations/001_init.sql",
+      "evidence_quote": "create type principal_kind as enum ('user','service_account','group');",
+      "explanation": "Checked-in SQL defines the allowed principal kinds."
+    },
+    {
+      "category": "contract",
+      "name": "event_publish",
+      "value": "rbac.assign-role reply: ok, error",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/nats/role_assigner.go",
+      "evidence_quote": "type assignRoleResponse struct {\n\tOK    bool   `json:\"ok\"`\n\tError string `json:\"error,omitempty\"`\n}",
+      "explanation": "Production subscriber code defines the request/reply response payload."
+    },
+    {
+      "category": "contract",
+      "name": "event_publish",
+      "value": "rbac.checkRole reply: ok, error",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/nats/role_checker.go",
+      "evidence_quote": "type roleCheckResponse struct {\n\tOK    bool   `json:\"ok\"`\n\tError string `json:\"error,omitempty\"`\n}",
+      "explanation": "Production subscriber code defines the role-check reply payload."
+    },
+    {
+      "category": "contract",
+      "name": "event_subscribe",
+      "value": "rbac.assign-role request: user_id, role",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/nats/role_assigner.go",
+      "evidence_quote": "type assignRoleRequest struct {\n\tUserID string `json:\"user_id\"`\n\tRole   string `json:\"role\"`\n}",
+      "explanation": "Production subscriber code defines the request payload for role assignment."
+    },
+    {
+      "category": "contract",
+      "name": "event_subscribe",
+      "value": "rbac.assign-role",
+      "confidence": 0.95,
+      "source_path": "internal/app/bootstrap.go",
+      "evidence_quote": "assigner := natsadapter.RoleAssigner{\n\t\t\tConn:        conn,\n\t\t\tSubject:     \"rbac.assign-role\",\n\t\t\tQueue:       \"ms-go-rbac\",",
+      "explanation": "Production bootstrap code configures a queue subscriber for the role-assignment subject."
+    },
+    {
+      "category": "contract",
+      "name": "event_subscribe",
+      "value": "rbac.checkRole request: user_id, role",
+      "confidence": 0.95,
+      "source_path": "internal/adapters/nats/role_checker.go",
+      "evidence_quote": "type roleCheckRequest struct {\n\tUserID string `json:\"user_id\"`\n\tRole   string `json:\"role\"`\n}",
+      "explanation": "Production subscriber code defines the role-check request payload."
+    },
+    {
+      "category": "contract",
+      "name": "event_subscribe",
+      "value": "rbac.checkRole",
+      "confidence": 0.95,
+      "source_path": "internal/app/bootstrap.go",
+      "evidence_quote": "checker := natsadapter.RoleChecker{\n\t\t\tConn:        conn,\n\t\t\tSubject:     \"rbac.checkRole\",\n\t\t\tQueue:       \"ms-go-rbac\",",
+      "explanation": "Production bootstrap code configures a queue subscriber for the role-check subject."
+    },
+    {
+      "category": "entity",
+      "name": "permission",
+      "value": "Permission",
+      "confidence": 0.92,
+      "source_path": "internal/domain/model/models.go",
+      "evidence_quote": "// Permission represents an action that can be applied to a resource kind.\ntype Permission struct {\n\tID           string\n\tAction       string\n\tResourceKind string\n}",
+      "explanation": "The production domain model defines the Permission entity."
+    },
+    {
+      "category": "entity",
+      "name": "principal_override",
+      "value": "PrincipalOverride",
+      "confidence": 0.938,
+      "source_path": "internal/domain/model/models.go",
+      "evidence_quote": "type PrincipalOverride struct {\n\tPrincipalID   string\n\tPrincipalKind PrincipalKind\n\tPermissionID  string\n\tEffect        OverrideEffect",
+      "explanation": "The production domain model defines principal permission overrides."
+    },
+    {
+      "category": "entity",
+      "name": "principal_role",
+      "value": "PrincipalRole",
+      "confidence": 0.938,
+      "source_path": "internal/domain/model/models.go",
+      "evidence_quote": "type PrincipalRole struct {\n\tPrincipalID   string\n\tPrincipalKind PrincipalKind\n\tRoleID        string\n\tTenantID      *string\n\tServiceID     *string\n\tResourceKind  *string\n\tResourceID    *string\n}",
+      "explanation": "The production domain model defines scoped principal-role assignments."
+    },
+    {
+      "category": "entity",
+      "name": "role",
+      "value": "Role",
+      "confidence": 0.92,
+      "source_path": "internal/domain/model/models.go",
+      "evidence_quote": "// Role represents a named role with a key.\ntype Role struct {\n\tID    string\n\tKey   string\n\tTitle string\n}",
+      "explanation": "The production domain model defines the Role entity."
+    },
+    {
+      "category": "entity",
+      "name": "service",
+      "value": "Service",
+      "confidence": 0.92,
+      "source_path": "internal/domain/model/models.go",
+      "evidence_quote": "// Service represents an external system registered within RBAC.\ntype Service struct {\n\tID    string\n\tKey   string\n\tTitle string\n}",
+      "explanation": "The production domain model defines the Service entity."
+    },
+    {
+      "category": "infrastructure",
+      "name": "CACHE_TTL_SECONDS",
+      "value": "60 seconds default",
+      "confidence": 0.94,
+      "source_path": "internal/config/config.go",
+      "evidence_quote": "ttl, err := parseDurationSeconds(getEnv(\"CACHE_TTL_SECONDS\", \"60\"))\n\tif err != nil {\n\t\treturn Config{}, fmt.Errorf(\"invalid CACHE_TTL_SECONDS: %w\", err)",
+      "explanation": "Production configuration parses the cache TTL as seconds and defaults it to 60."
+    },
+    {
+      "category": "infrastructure",
+      "name": "NATS",
+      "value": "Configured Core NATS request/reply broker",
+      "confidence": 0.94,
+      "source_path": "internal/app/bootstrap.go",
+      "evidence_quote": "if cfg.NATSURL != \"\" {\n\t\tconn, err := connectNATSWithRetry(cfg.NATSURL)\n\t\tif err != nil {\n\t\t\tpool.Close()\n\t\t\treturn nil, err\n\t\t}",
+      "explanation": "Production bootstrap connects to NATS when NATS_URL is nonempty and fails bootstrap if the connection cannot be established."
+    },
+    {
+      "category": "infrastructure",
+      "name": "PostgreSQL",
+      "value": "Required runtime database",
+      "confidence": 0.95,
+      "source_path": "internal/app/bootstrap.go",
+      "evidence_quote": "pool, err := connectPostgresWithRetry(cfg.DBDSN)\n\tif err != nil {\n\t\treturn nil, err\n\t}\n\tdbPool = pool",
+      "explanation": "Production bootstrap code requires a working PostgreSQL pool before constructing repositories."
+    },
+    {
+      "category": "infrastructure",
+      "name": "compose_dependency",
+      "value": "postgres service_healthy",
+      "confidence": 0.95,
+      "source_path": "docker-compose.yml",
+      "evidence_quote": "depends_on:\n      postgres:\n        condition: service_healthy\n    restart: unless-stopped",
+      "explanation": "The application Compose service waits for the PostgreSQL health condition."
+    },
+    {
+      "category": "infrastructure",
+      "name": "compose_service",
+      "value": "msgo-rbac",
+      "confidence": 0.95,
+      "source_path": "docker-compose.yml",
+      "evidence_quote": "msgo-rbac:\n    container_name: ms-rbac-service\n    build:\n      context: .\n      dockerfile: docker/Dockerfile",
+      "explanation": "The Compose manifest declares the application container and its build file."
+    },
+    {
+      "category": "infrastructure",
+      "name": "container_runtime",
+      "value": "gcr.io/distroless/base-debian12; port 8080",
+      "confidence": 0.95,
+      "source_path": "docker/Dockerfile",
+      "evidence_quote": "FROM gcr.io/distroless/base-debian12\nWORKDIR /app\nCOPY --from=builder /app/ms-rbac-service /app/ms-rbac-service\nEXPOSE 8080",
+      "explanation": "The runtime container uses a distroless Debian 12 base and exposes port 8080."
+    },
+    {
+      "category": "infrastructure",
+      "name": "network",
+      "value": "ms-net",
+      "confidence": 0.95,
+      "source_path": "docker-compose.yml",
+      "evidence_quote": "networks:\n  ms-net:\n    external: true",
+      "explanation": "The Compose manifest declares an externally managed network."
+    },
+    {
+      "category": "infrastructure",
+      "name": "postgres",
+      "value": "postgres:16-alpine",
+      "confidence": 0.95,
+      "source_path": "docker-compose.yml",
+      "evidence_quote": "services:\n  postgres:\n    container_name: ms-rbac-postgres\n    image: postgres:16-alpine",
+      "explanation": "The Compose manifest declares a PostgreSQL service and image."
+    },
+    {
+      "category": "infrastructure",
+      "name": "runtime_configuration",
+      "value": "HTTP_ADDR, DB_DSN, NATS_URL",
+      "confidence": 0.94,
+      "source_path": "internal/config/config.go",
+      "evidence_quote": "HTTPAddr:         getEnv(\"HTTP_ADDR\", \":8080\"),\n\t\tDBDSN:            os.Getenv(\"DB_DSN\"),\n\t\tNATSURL:          getEnv(\"NATS_URL\", \"nats://nats:4222\"),",
+      "explanation": "Production configuration code identifies the HTTP, database, and NATS settings and their applicable defaults."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "permission",
+      "confidence": 0.95,
+      "source_path": "migrations/001_init.sql",
+      "evidence_quote": "create table permission (\n  id uuid primary key default gen_random_uuid(),\n  action text not null,\n  resource_kind text not null,",
+      "explanation": "Checked-in SQL creates the table."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "principal_override",
+      "confidence": 0.95,
+      "source_path": "migrations/001_init.sql",
+      "evidence_quote": "create table principal_override (\n  principal_id uuid not null,\n  principal_kind principal_kind not null,\n  permission_id uuid not null references permission(id) on delete cascade,",
+      "explanation": "Checked-in SQL creates the table."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "principal_role",
+      "confidence": 0.95,
+      "source_path": "migrations/001_init.sql",
+      "evidence_quote": "create table principal_role (\n  principal_id uuid not null,\n  principal_kind principal_kind not null,\n  role_id uuid not null references role(id) on delete cascade,",
+      "explanation": "Checked-in SQL creates the table."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "role_hierarchy",
+      "confidence": 0.95,
+      "source_path": "migrations/001_init.sql",
+      "evidence_quote": "create table role_hierarchy (\n  role_id uuid not null references role(id) on delete cascade,\n  parent_role_id uuid not null references role(id) on delete cascade,",
+      "explanation": "Checked-in SQL creates the table."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "role_permission",
+      "confidence": 0.95,
+      "source_path": "migrations/001_init.sql",
+      "evidence_quote": "create table role_permission (\n  role_id uuid not null references role(id) on delete cascade,\n  permission_id uuid not null references permission(id) on delete cascade,",
+      "explanation": "Checked-in SQL creates the table."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "role",
+      "confidence": 0.95,
+      "source_path": "migrations/001_init.sql",
+      "evidence_quote": "create table role (\n  id uuid primary key default gen_random_uuid(),\n  key text not null,\n  title text not null,\n  unique (key)\n);",
+      "explanation": "Checked-in SQL creates the table."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "service_permission",
+      "confidence": 0.95,
+      "source_path": "migrations/001_init.sql",
+      "evidence_quote": "create table service_permission (\n  permission_id uuid not null references permission(id) on delete cascade,\n  service_id uuid not null references service(id) on delete cascade,",
+      "explanation": "Checked-in SQL creates the table."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "service_role",
+      "confidence": 0.95,
+      "source_path": "migrations/001_init.sql",
+      "evidence_quote": "create table service_role (\n  role_id uuid not null references role(id) on delete cascade,\n  service_id uuid not null references service(id) on delete cascade,",
+      "explanation": "Checked-in SQL creates the table."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "service",
+      "confidence": 0.95,
+      "source_path": "migrations/001_init.sql",
+      "evidence_quote": "create table service (\n  id uuid primary key default gen_random_uuid(),\n  key text unique not null,\n  title text not null\n);",
+      "explanation": "Checked-in SQL creates the table."
+    },
+    {
+      "category": "ownership",
+      "name": "database_table",
+      "value": "superadmin_principal",
+      "confidence": 0.95,
+      "source_path": "migrations/001_init.sql",
+      "evidence_quote": "create table superadmin_principal (\n  principal_id uuid primary key,\n  principal_kind principal_kind not null\n);",
+      "explanation": "Checked-in SQL creates the table."
+    },
+    {
+      "category": "purpose",
+      "name": "summary",
+      "value": "Go RBAC microservice for services, roles, permissions, and principal assignments",
+      "confidence": 0.901,
+      "source_path": "README.md",
+      "evidence_quote": "This repository provides a lightweight RBAC microservice implemented in Go. The service exposes administrative HTTP endpoints for managing services, roles, permissions, and principal assignments.",
+      "explanation": "The README directly identifies the repository as a Go RBAC microservice and summarizes its administrative scope."
+    }
+  ],
+  "rejected_facts": [
+    {
+      "category": "command",
+      "name": "migration_status",
+      "source_path": "Taskfile.yml",
+      "reason": "unexpanded_command_template"
+    }
+  ],
+  "open_questions": [
+    {
+      "question": "Which service or services publish requests to the two RBAC NATS subjects?",
+      "reason": "Production code establishes subscriptions but does not identify a connected publishing project.",
+      "source_paths": [
+        "internal/adapters/nats/role_assigner.go",
+        "internal/adapters/nats/role_checker.go",
+        "internal/app/bootstrap.go"
+      ]
+    },
+    {
+      "question": "Is NATS intended to be optional in deployed environments?",
+      "reason": "Bootstrap conditionally skips NATS only for an empty URL, while configuration supplies a nonempty default URL.",
+      "source_paths": [
+        "internal/app/bootstrap.go",
+        "internal/config/config.go"
+      ]
+    },
+    {
+      "question": "How are administrative and client HTTP endpoints authenticated and authorized?",
+      "reason": "Configuration declares moderator JWT issuer and audience fields, but the inspected production router mounts handlers without visible authentication middleware.",
+      "source_paths": [
+        "internal/adapters/http/router.go",
+        "internal/config/config.go"
+      ]
+    },
+    {
+      "question": "What is the intended CI pipeline?",
+      "reason": "No CI workflow or pipeline manifest was present among the inspected repository files.",
+      "source_paths": []
+    },
+    {
+      "question": "Why does the Docker builder use Go 1.25.1 while go.mod declares Go 1.22?",
+      "reason": "The two authoritative build files specify different Go versions.",
+      "source_paths": [
+        "docker/Dockerfile",
+        "go.mod"
+      ]
+    },
+    {
+      "question": "Is ms-go-user a runtime dependency or only the origin of seeded principal identifiers?",
+      "reason": "The migration comment names ms-go-user, but no production runtime call or direct dependency on that connected project was found.",
+      "source_paths": [
+        "migrations/002_seed_default_roles_and_principals.up.sql"
+      ]
+    },
+    {
+      "question": "Are role hierarchy, principal overrides, service-role links, service-permission links, and superadmin principals currently used at runtime?",
+      "reason": "The schema and domain models define them, but the inspected bootstrap wiring constructs repositories only for services, roles, permissions, principal roles, and role permissions.",
+      "source_paths": [
+        "internal/app/bootstrap.go",
+        "internal/domain/model/models.go",
+        "migrations/001_init.sql"
+      ]
+    }
+  ]
+}

--- a/.ai/service.yaml
+++ b/.ai/service.yaml
@@ -1,0 +1,513 @@
+schema_version: 1
+name: ms-go-rbac
+service_kind: backend_service
+repository_role: service
+repository:
+    git_url: https://github.com/bemulima/ms-go-rbac.git
+    default_branch: main
+    commit: ca10bb399b11ab2a7c19a83b960d90165b7dcd6c
+purpose: This repository provides a lightweight RBAC microservice implemented in Go. The service exposes administrative HTTP endpoints for managing services, roles, permissions, and principal assignments. Data is stored in Postgres via the migrations in `migrations/`, which keeps role assignments persistent across restarts.
+stack:
+    - name: container
+      value: docker
+      confidence: 0.95
+      source_path: docker/Dockerfile
+      explanation: A Dockerfile defines a container build.
+    - name: framework
+      value: nats
+      confidence: 0.98
+      source_path: go.mod
+      explanation: go.mod declares dependency github.com/nats-io/nats.go.
+    - name: framework
+      value: pgx
+      confidence: 0.98
+      source_path: go.mod
+      explanation: go.mod declares dependency github.com/jackc/pgx.
+    - name: language
+      value: go
+      confidence: 1
+      source_path: go.mod
+      explanation: go.mod is the canonical Go module manifest.
+    - name: orchestration
+      value: docker_compose
+      confidence: 0.98
+      source_path: docker-compose.yml
+      explanation: A Docker Compose manifest defines local infrastructure or runtime services.
+capabilities:
+    - name: business capability
+      value: Versioned RBAC administration API
+      confidence: 0.93
+      source_path: internal/adapters/http/router.go
+      explanation: Semantic proposal with a verified repository quote. Production routing code mounts the administrative API beneath this prefix.
+    - name: business capability
+      value: Versioned principal role and permission API
+      confidence: 0.93
+      source_path: internal/adapters/http/router.go
+      explanation: Semantic proposal with a verified repository quote. Production routing code mounts the client API beneath this prefix.
+    - name: event_subject
+      value: rbac.assign-role
+      confidence: 0.72
+      source_path: README.md
+      explanation: A NATS/event-related source line references this subject.
+    - name: event_subject
+      value: rbac.assign-role
+      confidence: 0.72
+      source_path: internal/app/bootstrap.go
+      explanation: A NATS/event-related source line references this subject.
+    - name: event_subject
+      value: rbac.checkRole
+      confidence: 0.72
+      source_path: README.md
+      explanation: A NATS/event-related source line references this subject.
+    - name: event_subject
+      value: rbac.checkRole
+      confidence: 0.72
+      source_path: internal/app/bootstrap.go
+      explanation: A NATS/event-related source line references this subject.
+    - name: http_route
+      value: ANY /permission-list
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /permission/
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /permission
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /principal-permission/get-by-permission
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /principal-permission/list
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /principal-role/get-by-role
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /principal-role/get
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /principal-role/update
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /role-list
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /role-permission
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /role/
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /role
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /service-list
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /service/
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: ANY /service
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: A net/http HandleFunc registration exposes this route without a single-method guard.
+    - name: http_route
+      value: GET /admin/v1/permission-list
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/admin.go
+      explanation: Semantic proposal with a verified repository quote. The production permission-list handler only accepts GET.
+    - name: http_route
+      value: GET /admin/v1/role-list
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/admin.go
+      explanation: Semantic proposal with a verified repository quote. The production role-list handler only accepts GET.
+    - name: http_route
+      value: GET /admin/v1/service-list
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/admin.go
+      explanation: Semantic proposal with a verified repository quote. The production list handler only accepts GET.
+    - name: http_route
+      value: GET /api/v1/principal-permission/get-by-permission
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/api.go
+      explanation: Semantic proposal with a verified repository quote. The production permission-check handler only accepts GET.
+    - name: http_route
+      value: GET /api/v1/principal-permission/list
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/api.go
+      explanation: Semantic proposal with a verified repository quote. The production principal-permission list handler only accepts GET.
+    - name: http_route
+      value: GET /api/v1/principal-role/get-by-role
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/api.go
+      explanation: Semantic proposal with a verified repository quote. The production role-check handler only accepts GET.
+    - name: http_route
+      value: GET /api/v1/principal-role/get
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/api.go
+      explanation: Semantic proposal with a verified repository quote. The production principal-role lookup handler only accepts GET.
+    - name: http_route
+      value: GET|PUT /admin/v1/permission/{id}
+      confidence: 0.95
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: Semantic proposal with a verified repository quote. The admin router registers GET and PUT permission handlers on the identifier path.
+    - name: http_route
+      value: GET|PUT /admin/v1/role/{id}
+      confidence: 0.95
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: Semantic proposal with a verified repository quote. The admin router registers GET and PUT role handlers on the identifier path.
+    - name: http_route
+      value: GET|PUT /admin/v1/service/{id}
+      confidence: 0.95
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: Semantic proposal with a verified repository quote. The admin router registers GET and PUT service handlers on the identifier path.
+    - name: http_route
+      value: PATCH /api/v1/principal-role/update
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/api.go
+      explanation: Semantic proposal with a verified repository quote. The production principal-role update handler only accepts PATCH.
+    - name: http_route
+      value: POST /admin/v1/role-permission
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/admin.go
+      explanation: Semantic proposal with a verified repository quote. The production role-permission assignment handler only accepts POST.
+    - name: http_route
+      value: SET /admin/v1/permission
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/admin.go
+      explanation: Semantic proposal with a verified repository quote. The production handler accepts the nonstandard SET method for permission creation.
+    - name: http_route
+      value: SET /admin/v1/role
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/admin.go
+      explanation: Semantic proposal with a verified repository quote. The production handler accepts the nonstandard SET method for role creation.
+    - name: http_route
+      value: SET /admin/v1/service
+      confidence: 0.95
+      source_path: internal/adapters/http/handlers/admin.go
+      explanation: Semantic proposal with a verified repository quote. The production handler accepts the nonstandard SET method for service creation.
+ownership:
+    - name: database_table
+      value: permission
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: principal_override
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: principal_role
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: role_hierarchy
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: role_permission
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: role
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: service_permission
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: service_role
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: service
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+    - name: database_table
+      value: superadmin_principal
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: A checked-in SQL schema file creates this table, indicating schema ownership.
+dependencies:
+    - name: depends_on
+      value: postgres
+      confidence: 0.9
+      source_path: docker-compose.yml
+      explanation: Docker Compose declares this service dependency.
+contracts:
+    - name: database_schema
+      value: 'default roles: admin, moderator, teacher, student, user, guest'
+      confidence: 0.95
+      source_path: migrations/002_seed_default_roles_and_principals.up.sql
+      explanation: Semantic proposal with a verified repository quote. Checked-in migration SQL seeds these role keys.
+    - name: database_schema
+      value: migrations/001_init.sql
+      confidence: 0.96
+      source_path: migrations/001_init.sql
+      explanation: The SQL file creates database resources owned by the project.
+    - name: database_schema
+      value: override_effect=allow|deny
+      confidence: 0.95
+      source_path: migrations/001_init.sql
+      explanation: Semantic proposal with a verified repository quote. Checked-in SQL defines the allowed override effects.
+    - name: database_schema
+      value: principal_kind=user|service_account|group
+      confidence: 0.95
+      source_path: migrations/001_init.sql
+      explanation: Semantic proposal with a verified repository quote. Checked-in SQL defines the allowed principal kinds.
+    - name: event_publish
+      value: 'rbac.assign-role reply: ok, error'
+      confidence: 0.95
+      source_path: internal/adapters/nats/role_assigner.go
+      explanation: Semantic proposal with a verified repository quote. Production subscriber code defines the request/reply response payload.
+    - name: event_publish
+      value: 'rbac.checkRole reply: ok, error'
+      confidence: 0.95
+      source_path: internal/adapters/nats/role_checker.go
+      explanation: Semantic proposal with a verified repository quote. Production subscriber code defines the role-check reply payload.
+    - name: event_subscribe
+      value: 'rbac.assign-role request: user_id, role'
+      confidence: 0.95
+      source_path: internal/adapters/nats/role_assigner.go
+      explanation: Semantic proposal with a verified repository quote. Production subscriber code defines the request payload for role assignment.
+    - name: event_subscribe
+      value: rbac.assign-role
+      confidence: 0.95
+      source_path: internal/app/bootstrap.go
+      explanation: Semantic proposal with a verified repository quote. Production bootstrap code configures a queue subscriber for the role-assignment subject.
+    - name: event_subscribe
+      value: 'rbac.checkRole request: user_id, role'
+      confidence: 0.95
+      source_path: internal/adapters/nats/role_checker.go
+      explanation: Semantic proposal with a verified repository quote. Production subscriber code defines the role-check request payload.
+    - name: event_subscribe
+      value: rbac.checkRole
+      confidence: 0.95
+      source_path: internal/app/bootstrap.go
+      explanation: Semantic proposal with a verified repository quote. Production bootstrap code configures a queue subscriber for the role-check subject.
+    - name: http_produce
+      value: ANY /permission-list
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+    - name: http_produce
+      value: ANY /permission/
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+    - name: http_produce
+      value: ANY /permission
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+    - name: http_produce
+      value: ANY /principal-permission/get-by-permission
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+    - name: http_produce
+      value: ANY /principal-permission/list
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+    - name: http_produce
+      value: ANY /principal-role/get-by-role
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+    - name: http_produce
+      value: ANY /principal-role/get
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+    - name: http_produce
+      value: ANY /principal-role/update
+      confidence: 0.72
+      source_path: internal/adapters/http/api/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+    - name: http_produce
+      value: ANY /role-list
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+    - name: http_produce
+      value: ANY /role-permission
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+    - name: http_produce
+      value: ANY /role/
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+    - name: http_produce
+      value: ANY /role
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+    - name: http_produce
+      value: ANY /service-list
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+    - name: http_produce
+      value: ANY /service/
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+    - name: http_produce
+      value: ANY /service
+      confidence: 0.72
+      source_path: internal/adapters/http/admin/v1/router.go
+      explanation: The service implementation provides this HTTP contract.
+infrastructure:
+    - name: CACHE_TTL_SECONDS
+      value: 60 seconds default
+      confidence: 0.94
+      source_path: internal/config/config.go
+      explanation: Semantic proposal with a verified repository quote. Production configuration parses the cache TTL as seconds and defaults it to 60.
+    - name: NATS
+      value: Configured Core NATS request/reply broker
+      confidence: 0.94
+      source_path: internal/app/bootstrap.go
+      explanation: Semantic proposal with a verified repository quote. Production bootstrap connects to NATS when NATS_URL is nonempty and fails bootstrap if the connection cannot be established.
+    - name: PostgreSQL
+      value: Required runtime database
+      confidence: 0.95
+      source_path: internal/app/bootstrap.go
+      explanation: Semantic proposal with a verified repository quote. Production bootstrap code requires a working PostgreSQL pool before constructing repositories.
+    - name: compose_dependency
+      value: postgres service_healthy
+      confidence: 0.95
+      source_path: docker-compose.yml
+      explanation: Semantic proposal with a verified repository quote. The application Compose service waits for the PostgreSQL health condition.
+    - name: compose_service
+      value: msgo-rbac
+      confidence: 0.96
+      source_path: docker-compose.yml
+      explanation: Docker Compose declares this service.
+    - name: compose_service
+      value: postgres=postgres:16-alpine
+      confidence: 0.96
+      source_path: docker-compose.yml
+      explanation: Docker Compose declares this service.
+    - name: container_runtime
+      value: gcr.io/distroless/base-debian12; port 8080
+      confidence: 0.95
+      source_path: docker/Dockerfile
+      explanation: Semantic proposal with a verified repository quote. The runtime container uses a distroless Debian 12 base and exposes port 8080.
+    - name: network
+      value: ms-net
+      confidence: 0.95
+      source_path: docker-compose.yml
+      explanation: Semantic proposal with a verified repository quote. The Compose manifest declares an externally managed network.
+    - name: postgres
+      value: postgres:16-alpine
+      confidence: 0.95
+      source_path: docker-compose.yml
+      explanation: Semantic proposal with a verified repository quote. The Compose manifest declares a PostgreSQL service and image.
+    - name: runtime_configuration
+      value: HTTP_ADDR, DB_DSN, NATS_URL
+      confidence: 0.94
+      source_path: internal/config/config.go
+      explanation: Semantic proposal with a verified repository quote. Production configuration code identifies the HTTP, database, and NATS settings and their applicable defaults.
+business_rules:
+    - name: permission_identifier_format
+      value: action:resource_kind
+      confidence: 0.93
+      source_path: internal/usecase/principal.go
+      explanation: Semantic proposal with a verified repository quote. Production use-case code defines the combined permission identifier format.
+    - name: principal_permission_match
+      value: Permission checks use exact identifier equality
+      confidence: 0.94
+      source_path: internal/usecase/principal.go
+      explanation: Semantic proposal with a verified repository quote. A permission check succeeds only when the requested identifier exactly matches one resolved identifier.
+    - name: principal_role_assignment_idempotency
+      value: Reassigning the same existing role succeeds without a database update
+      confidence: 0.94
+      source_path: internal/usecase/principal.go
+      explanation: Semantic proposal with a verified repository quote. Production use-case code makes repeated assignment of the current nonempty role a no-op.
+    - name: principal_role_match
+      value: Role checks require an exact nonempty role match
+      confidence: 0.94
+      source_path: internal/usecase/principal.go
+      explanation: Semantic proposal with a verified repository quote. A role check succeeds only when the stored role equals the trimmed requested role and is nonempty.
+entities:
+    - name: permission
+      value: Permission
+      confidence: 0.92
+      source_path: internal/domain/model/models.go
+      explanation: Semantic proposal with a verified repository quote. The production domain model defines the Permission entity.
+    - name: principal_override
+      value: PrincipalOverride
+      confidence: 0.938
+      source_path: internal/domain/model/models.go
+      explanation: Semantic proposal with a verified repository quote. The production domain model defines principal permission overrides.
+    - name: principal_role
+      value: PrincipalRole
+      confidence: 0.938
+      source_path: internal/domain/model/models.go
+      explanation: Semantic proposal with a verified repository quote. The production domain model defines scoped principal-role assignments.
+    - name: role
+      value: Role
+      confidence: 0.92
+      source_path: internal/domain/model/models.go
+      explanation: Semantic proposal with a verified repository quote. The production domain model defines the Role entity.
+    - name: service
+      value: Service
+      confidence: 0.92
+      source_path: internal/domain/model/models.go
+      explanation: Semantic proposal with a verified repository quote. The production domain model defines the Service entity.
+instructions:
+    - AGENTS.md
+    - prompts/git-workflow.md
+commands:
+    - migrate_up
+    - run_linter
+    - run_service
+    - run_tests
+    - start_containers
+    - stop_containers
+discovery:
+    snapshot_id: 55d4a02a-38fd-497f-b50d-fa6a6ce1f538
+    commit: ca10bb399b11ab2a7c19a83b960d90165b7dcd6c
+    branch: main
+    dirty: false
+    content_checksum: cdca68d85e39f86cf6d4d30df59c70fb8d86e63cf652ec9aa9f7a14b39d998a0

--- a/.ai/workflows/change-contract.yaml
+++ b/.ai/workflows/change-contract.yaml
@@ -1,0 +1,9 @@
+schema_version: 1
+name: change-contract
+requires_approval: true
+steps:
+    - identify producers and consumers
+    - update versioned contract evidence
+    - check compatibility and drift
+    - run repository verification
+    - request independent review

--- a/.ai/workflows/implement-feature.yaml
+++ b/.ai/workflows/implement-feature.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+name: implement-feature
+requires_approval: true
+steps:
+    - read .ai/service.yaml and linked instructions
+    - implement within approved write scope
+    - run .ai/workflows/test.yaml when present
+    - request independent review

--- a/.ai/workflows/test.yaml
+++ b/.ai/workflows/test.yaml
@@ -1,0 +1,6 @@
+schema_version: 1
+name: test
+requires_approval: false
+steps:
+    - go test ./...
+    - golangci-lint run ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,9 @@ git-backed repositories under `/Users/marat/Developments/microservices`.
 
 ## Repository-Specific Notes
 - Add repo-specific instructions here when needed.
+
+<!-- agent-orchestrator:start -->
+## Agent Orchestrator (Managed)
+
+Read `.ai/service.yaml` before repository work. Follow every linked repository instruction and prompt. Do not edit files outside an explicitly approved write scope.
+<!-- agent-orchestrator:end -->


### PR DESCRIPTION
## Summary
- add schema-16 evidence-backed `.ai/**` RBAC context
- document authorization rules, NATS contracts, and SQL-backed ownership
- keep the possible ms-go-user relationship unresolved instead of asserting a runtime dependency
- reject the unexpanded Taskfile command template

## Verification
- orchestrator dry-run passed
- generated formats passed
- write scope limited to `AGENTS.md` and `.ai/**`
- exact source/published tree hashes matched
- source checkout unchanged

This supersedes #8. Seven unresolved repository questions remain explicitly recorded.